### PR TITLE
Disable internal touch handling

### DIFF
--- a/resources/aap_system_attributes.xml
+++ b/resources/aap_system_attributes.xml
@@ -20,7 +20,7 @@ Refer the Configuration Parameters in the Appendix section of API documentation 
         </display>
         <input_devices>
              <touch_screen>
-                <use_internally>true</use_internally>
+                <use_internally>false</use_internally>
                 <path>/dev/input/filtered-touchscreen0</path>
                 <type>AAP_TOUCH_SCREEN_TYPE_CAPACITIVE</type>
                 <as_secondary_input>false</as_secondary_input>


### PR DESCRIPTION
When use_internally is set to true, aap_service attempts to handle touch events on its own, which can interfere with libpatch-blmjciaapa.so