### PR TITLE
feat(hud): render Android Auto GAL 1.6 navigation guidance on the HUD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
-# Compile-only check to catch breakage before a release tag is cut.
-# Builds both configs and packages the same two tarballs the release
-# workflow ships (versioned by short SHA instead of a tag), so what CI
-# produces matches a real release.
+# Catches breakage before a release tag is cut: runs the host self-tests
+# (test/nav16_test), then builds both configs and packages the same two
+# tarballs the release workflow ships (versioned by short SHA instead of
+# a tag), so what CI produces matches a real release.
 # Tag pushes are intentionally NOT built here — release.yml owns those.
 on:
   # Only main on push; PR branches are covered by pull_request below.
@@ -22,6 +22,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Host self-tests — pure g++ builds that run on the runner itself, so
+  # this job needs no cross toolchain and reports independently of the
+  # (slower) ARM build job. Only nav16_test qualifies: gsi_test/lane_test
+  # are on-device ARM tools (lane_test also needs a local-only dbus header).
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Build nav16_test (host g++)
+        run: make -C test nav16_test
+
+      - name: Run nav16_test
+        run: ./test/build/nav16_test
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ actually needs.
 | --- | --- |
 | `mazda/` | Source code and build system for the on-device shims. Anything that gets cross-compiled lives here. |
 | `mazda/patches/` | One subdirectory per OEM `.so` we patch. The directory name is the OEM library's basename without the extension. |
-| `mazda/patches/blmjciaapa/` | Sources for `libpatch-blmjciaapa.so` — hooks into `blmjciaapa.so` (loaded by the `{L_jciAAPA}` `sm_svclauncher` PID) to add Android Auto touch passthrough and HUD guidance. |
+| `mazda/patches/blmjciaapa/` | Sources for `libpatch-blmjciaapa.so` — hooks into `blmjciaapa.so` (loaded by the `{L_jciAAPA}` `sm_svclauncher` PID) to add Android Auto touch passthrough and HUD guidance, including the GAL 1.6 maneuver/lane guidance relayed from the `aap_service` shim. |
+| `mazda/patches/aap_service/` | Sources for `libpatch-aap_service.so` — hooks into `aap_service` (the Android Auto projection daemon) to advertise GAL protocol 1.6, so the phone sends the richer navigation (maneuver, lanes, distance), and relays those frames to `libpatch-blmjciaapa.so` for the HUD. Optional: only needed with `use_protocol_v1_6 = true`. |
 | `mazda/patches/svcjcinavi/` | Sources for `libpatch-svcjcinavi.so` — hooks into `svcjcinavi.so` (the OEM navigation service PID) to merge Android Auto HUD guidance with the OEM nav engine's so the head-up display doesn't flicker between the two. Optional: only useful when the navigation SD card is present (without it `svcjcinavi` never runs). |
 | `mazda/Makefile` | Multi-target cross-compile build system. Targets: `make debug`, `make release` (default), `make all`, `make <patch>` / `make <patch>-debug`, `make clean`. Outputs go to `mazda/build/{debug,release}/libpatch-<patch>.so`. |
 | `mazda/m3-toolchain/` | Git submodule: ARM Cortex-A9 NEON GCC 4.9.1 cross toolchain (`arm-cortexa9_neon-linux-gnueabi`) plus sysroot matching the CMU's glibc. Source: <https://github.com/lmagder/m3-toolchain>. |

--- a/docs/build.md
+++ b/docs/build.md
@@ -16,14 +16,16 @@ make -C mazda blmjciaapa         # release build of just one patch
 make -C mazda blmjciaapa-debug   # debug build of just one patch
 make -C mazda svcjcinavi         # release build of the other patch
 make -C mazda svcjcinavi-debug   # debug build of the other patch
+make -C mazda aap_service        # release build of the aap_service patch
+make -C mazda aap_service-debug  # debug build of the aap_service patch
 make -C mazda clean
 ```
 
 Or use the VS Code tasks (`Ctrl+Shift+B` runs **Build Release**).
 
 Outputs land at `mazda/build/{debug,release}/libpatch-<name>.so` (one
-per patch — currently `libpatch-blmjciaapa.so` and
-`libpatch-svcjcinavi.so`). The `libpatch-` prefix is project convention
+per patch — currently `libpatch-blmjciaapa.so`, `libpatch-svcjcinavi.so`,
+and `libpatch-aap_service.so`). The `libpatch-` prefix is project convention
 so a quick `ls /jci/lib/libpatch-*` on the device shows everything we
 ship without colliding with stock OEM libraries.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,7 @@ everything the on-device install needs:
 oem-aa-mod-<version>/
   libpatch-blmjciaapa.so              # -> /data_persist/oem-aa-mod/
   libpatch-svcjcinavi.so              # -> /data_persist/oem-aa-mod/ (optional; HUD merge)
+  libpatch-aap_service.so             # -> /data_persist/oem-aa-mod/ (optional; protocol v1.6)
   resources/
     aap_system_attributes.xml         # -> /etc/
     aap_system_attributes_UCP.xml     # -> /etc/
@@ -48,6 +49,10 @@ cp /mnt/sdb1/libpatch-blmjciaapa.so /data_persist/oem-aa-mod/
 # Optional: the HUD-merge shim (only useful with the nav SD card; see
 # hud_transport=svcnavi under Configuration below).
 cp /mnt/sdb1/libpatch-svcjcinavi.so /data_persist/oem-aa-mod/
+# Optional: the protocol v1.6 shim (only needed for use_protocol_v1_6=true;
+# enables lane guidance on the HUD; see Configuration below). Inert unless
+# that key is set.
+cp /mnt/sdb1/libpatch-aap_service.so /data_persist/oem-aa-mod/
 # Optional: runtime config (see Configuration below). Omit it to use
 # the built-in defaults.
 cp /mnt/sdb1/libpatch.conf /data_persist/oem-aa-mod/
@@ -114,6 +119,24 @@ want to patch.
 </service>
 ```
 
+**`aap_service`** (only needed for Android Auto GAL 1.6 — i.e.
+`use_protocol_v1_6 = true`). Find the `<service … name="aap_service" …>` block
+and add the same env var inside it:
+
+```xml
+<service type="process" name="aap_service" path="/usr/bin/aap_service" …>
+    <!-- existing entries left in place -->
+    <environ_var env_name="LD_PRELOAD"
+                 env_value="/data_persist/oem-aa-mod/libpatch-aap_service.so"/>
+</service>
+```
+
+For 1.6 HUD guidance BOTH `jciAAPA` (blmjciaapa) and `aap_service` must be
+preloaded: the aap_service shim advertises 1.6 and forwards the decoded
+navigation to the blmjciaapa shim, which renders it on the HUD. With
+`use_protocol_v1_6 = false` (the default) the aap_service shim is inert, so there
+is no reason to preload it unless you are enabling 1.6.
+
 (Leave the existing `<dependency>`/`<connection>`/attributes exactly as
 they are — only the `<environ_var>` line is added.) Skip this block
 entirely if you aren't using the svcnavi HUD transport; the shim
@@ -169,7 +192,9 @@ case-insensitive.
 | `hud` | `true` / `false` | `true` | Enable HUD guidance forwarding (turn arrow + distance to the head-up display). |
 | `hud_transport` | `svcnavi` / `vbs` | `svcnavi` | Which path HUD guidance takes (only relevant when `hud = true`). |
 | `force_street_name` | `true` / `false` | `false` | Force the Android Auto street name onto the HUD street line even where the OEM blanks it (see the EU note below). |
-| `hud_fold_latin` | `true` / `false` | `true` | Fold HUD-unrenderable precomposed Latin letters in street names to their base forms (see the note below). |
+| `hud_fold_latin` | `true` / `false` | `false` | Fold HUD-unrenderable precomposed Latin letters in street names to their base forms (see the note below). |
+| `use_protocol_v1_6` | `true` / `false` | `false` | Advertise Android Auto GAL 1.6 so the phone sends the 1.6 navigation protocol (maneuver / lanes / distance) for the HUD. Read by the `aap_service` shim; requires it to be preloaded (see the note below). |
+| `hud_lanes` | `true` / `false` | `true` | Send Android Auto lane guidance to the HUD (kill-switch for the lane path on both transports). Only carries data when `use_protocol_v1_6 = true`; set `false` to disable lane sends without redeploying (see the note below). |
 
 Booleans are lenient — `true`/`1`/`yes`/`on` and `false`/`0`/`no`/`off`
 are all accepted.
@@ -207,8 +232,8 @@ the street, so it is safe to enable everywhere if preferred.
   3-byte-UTF-8 character renders as a blank space. For **precomposed
   Latin letters** — the Latin Extended Additional block (`U+1E00`–`U+1EFF`),
   where each character is a base letter plus diacritics — we can fold to
-  the renderable base instead of losing them. With this enabled (the
-  default) each such letter is folded to its base, keeping a renderable
+  the renderable base instead of losing them. When enabled, each such
+  letter is folded to its base, keeping a renderable
   accent where the letter is defined by one (`ă â ê ô ơ ư`) and dropping
   only the marks the font can't draw: `ễ`→`ê`, `ớ`→`ơ`, `ậ`→`â`,
   `ḍ`→`d`, `ṛ`→`r`, `ẁ`→`w`. So a name the font shows as `Nguy n Phư c`
@@ -218,15 +243,33 @@ the street, so it is safe to enable everywhere if preferred.
   — is passed through unchanged, so it is harmless everywhere. Set
   `false` to send names verbatim. Applies to both HUD transports.
 
+- **`use_protocol_v1_6`** advertises Android Auto **GAL 1.6** to the phone (the
+  OEM advertises 1.5). At 1.5 the phone only sends the deprecated turn events; at
+  1.6 it sends the full navigation protocol — maneuver, **lanes**, distance — which
+  is what feeds the richer HUD guidance. The `aap_service` shim catches and decodes
+  the 1.6 frames and forwards them to the `blmjciaapa` shim, which renders them on
+  the HUD via the same `hud` / `hud_transport` path as the 1.5 guidance. So this
+  needs the `aap_service` shim preloaded (step 2) **in addition to** `jciAAPA`; the
+  other libraries ignore the key. The GAL version is negotiated once per session,
+  so a change takes effect on the next Android Auto connection (restart `jciAAPA`
+  + `aap_service`, or reconnect the phone). Default `false` = stock 1.5.
+  Lanes are gated separately by `hud_lanes` (below).
+
+- **`hud_lanes`** controls whether lane guidance is sent to the HUD. It defaults to
+  `true`; set it `false` to stop the shim from sending lane data. Lanes only appear
+  with `use_protocol_v1_6 = true`, so on a stock 1.5 setup this key has no effect.
+
 After editing `libpatch.conf`, restart the affected service(s) —
-`jciAAPA`, and `jcinavi` if you patched it — or reboot for the change to
-take effect. The config is read once at library load.
+`jciAAPA`, `jcinavi` if you patched it, and `aap_service` if you enabled
+`use_protocol_v1_6` — or reboot for the change to take effect. The config is read
+once at library load.
 
 ## Uninstall / disable
 
 Remove (or comment out) the `<environ_var>` line(s) you added in
-`/jci/sm/sm.conf` (the `jciAAPA` one, and the `jcinavi` one if present),
-restore the original `/etc/aap_system_attributes*.xml` files from the
-`.orig` backups, then restart the affected services (`smctl -r -n
-jciAAPA` / `smctl -r -n jcinavi`) or reboot. The
+`/jci/sm/sm.conf` (the `jciAAPA` one, the `jcinavi` one if present, and the
+`aap_service` one if you enabled 1.6), restore the original
+`/etc/aap_system_attributes*.xml` files from the `.orig` backups, then restart
+the affected services (`smctl -r -n jciAAPA` / `smctl -r -n jcinavi` /
+`smctl -r -n aap_service`) or reboot. The
 `/data_persist/oem-aa-mod/` directory can be deleted afterwards.

--- a/mazda/Makefile
+++ b/mazda/Makefile
@@ -26,7 +26,7 @@ CXX         := $(M3TOOLCHAIN)/bin/$(TRIPLE)-g++
 SYSROOT     := $(M3TOOLCHAIN)/$(TRIPLE)/sysroot
 
 # OEM libraries we patch. Order doesn't matter.
-PATCHES := blmjciaapa svcjcinavi
+PATCHES := blmjciaapa svcjcinavi aap_service
 
 # pkg-config wrapper pointed at the device's sysroot so it resolves
 # against the cross-compiled .pc files (not the host's). Same pattern
@@ -65,7 +65,10 @@ COMMON_CXXFLAGS := -std=c++11 \
                    -fvisibility=hidden \
                    -D_GLIBCXX_USE_CXX11_ABI=0 \
                    -Ipatches \
-                   $(PKG_CFLAGS)
+                   $(PKG_CFLAGS) \
+                   $(EXTRA_CXXFLAGS)
+# EXTRA_CXXFLAGS: appended to every compile. E.g. verbose logs in a release lib:
+#   make ... EXTRA_CXXFLAGS='-DLOG_LEVEL=LOG_LEVEL_VERBOSE'
 # -D_GLIBCXX_USE_CXX11_ABI=0 selects the pre-C++11 (COW) std::string
 # and std::list ABI. The device ships libstdc++.so.6.0.14 (GCC 4.6
 # era) which only knows that ABI; libdbus-c++-1.so is linked against

--- a/mazda/patches/aap_service/log.h
+++ b/mazda/patches/aap_service/log.h
@@ -1,0 +1,11 @@
+// aap_service logging shim — sets the library name and pulls in the
+// shared logging helper (patches/common/log.h). Per-TU includes are
+// `#include "log.h"`; set LOG_TAG before including to label the line.
+
+#ifndef LIBPATCH_AAP_SERVICE_LOG_H
+#define LIBPATCH_AAP_SERVICE_LOG_H
+
+#define LIBPATCH_NAME "aap_service"
+#include "common/log.h"
+
+#endif // LIBPATCH_AAP_SERVICE_LOG_H

--- a/mazda/patches/aap_service/main.cpp
+++ b/mazda/patches/aap_service/main.cpp
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// libpatch-aap_service.so — LD_PRELOAD shim for the Mazda CMU `aap_service` PID
+// (the Android Auto projection daemon). Surfaces Android Auto turn-by-turn
+// guidance for the Mazda Active Driving Display (HUD).
+//
+// Android Auto only sends structured navigation — NavigationState (maneuver +
+// lanes) and CurrentPosition (distance + ETA) — when the head unit advertises
+// GAL protocol >= 1.6. The OEM advertises 1.5, at which the phone sends only the
+// deprecated turn events. With `use_protocol_v1_6 = true` in libpatch.conf this
+// shim:
+//
+//   1. Bumps the advertised GAL version 1.5 -> 1.6 by patching one instruction
+//      in Controller::sendVersionRequest (mov r2,#5 -> mov r2,#6).
+//   2. Vtable-hooks NavigationStatusEndpoint::routeMessage and swallows the 1.6
+//      navigation message range (0x8001..0x8007). The OEM 1.5 endpoint has no
+//      parser for those ids and returns STATUS_UNEXPECTED_MESSAGE (-253), which
+//      MessageRouter turns into a {00 FF} frame the phone treats as a protocol
+//      violation -> Android Auto tears down. Returning 0 ("handled") for the
+//      whole range prevents that.
+//
+// This shim does NOT parse or render anything. aap_service and jciAAPA are
+// separate processes; the entire 1.6 decoder + HUD renderer (protobuf decode,
+// glyph map, street fold, vbs/svcnavi transport, lanes) lives in the blmjciaapa
+// shim. This shim just RELAYS the raw nav frames it swallows — an AaNav16Hdr +
+// the original frame bytes — over an abstract AF_UNIX datagram socket to
+// blmjciaapa, which decodes and renders them. See common/aa_nav16_msg.h.
+//
+// With `use_protocol_v1_6 = false` (the default) the shim is inert: the version
+// stays 1.5 and the hook is not installed, so the unit behaves stock.
+//
+// Addresses are for firmware 74.00.324A /usr/bin/aap_service, a non-PIE ELF
+// (fixed virtual addresses, no load-base math). Every patch site is byte-verified
+// before writing and aborts on mismatch — aap_service runs reset_board="yes", so
+// a wrong write must fail safe (no patch).
+//
+//   Controller::sendVersionRequest               @ 0x00173dfc
+//     minor-version insn `mov r2,#5` (e3a02005)  @ 0x00173eb4
+//   _ZTV24NavigationStatusEndpoint               @ 0x001f7d10
+//     routeMessage vtable slot[7]                @ 0x001f7d2c  (= 0x0017be10)
+//   NavigationStatusEndpoint::routeMessage       @ 0x0017be10
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE          // dladdr (config.h), abstract sockets; precede includes
+#endif
+
+#define LOG_TAG "CORE"
+#include "log.h"                    // LIBPATCH_NAME + shared LOG* macros
+#include "common/preload_guard.h"   // preload_in_aap_service(), crash handler
+#include "common/config.h"          // libpatch_config::{use_protocol_v1_6, load}
+#include "common/aa_nav16_msg.h"    // AaNav16Hdr raw-frame envelope + socket name
+
+#include <cstdint>
+#include <cstddef>           // offsetof
+#include <cstring>           // memset/memcpy/strncpy/strerror
+#include <cerrno>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace {
+
+// ---- pinned addresses (firmware 74.00.324A aap_service, non-PIE) -----------
+constexpr uintptr_t kVersionInsnAddr  = 0x00173eb4;  // `mov r2,#5`
+constexpr uint32_t  kVersionInsnOld   = 0xe3a02005;  // mov r2,#5 (minor=5)
+constexpr uint32_t  kVersionInsnNew   = 0xe3a02006;  // mov r2,#6 (minor=6)
+
+constexpr uintptr_t kVtableSlotAddr   = 0x001f7d2c;  // NavigationStatusEndpoint vtable slot[7]
+constexpr uintptr_t kRouteMessageAddr = 0x0017be10;  // NavigationStatusEndpoint::routeMessage
+
+// IoBuffer accessors routeMessage itself uses to read the inbound frame; reused
+// to read the protobuf body of the 1.6 frames we decode.
+constexpr uintptr_t kSharedPtrDeref = 0x0016f810;  // shared_ptr<IoBuffer>::operator-> -> IoBuffer*
+constexpr uintptr_t kIoBufferRaw    = 0x0016f2f8;  // IoBuffer::raw()  -> uint8_t* (msgId at [0:2])
+constexpr uintptr_t kIoBufferSize   = 0x0016f330;  // IoBuffer::size() -> int (total, incl 2-byte id)
+
+// routeMessage(unsigned char chan, unsigned short msgId,
+// const shared_ptr<IoBuffer>&) -> int. AAPCS: r0=this, r1=chan, r2=msgId,
+// r3=&shared_ptr; narrow args arrive widened to 32 bits.
+typedef int      (*route_fn)(void *self, uint32_t chan, uint32_t msgId, const void *iobuf_ref);
+typedef void *   (*sp_deref_fn)(const void *sp);   // shared_ptr<IoBuffer>::operator->
+typedef uint8_t *(*iob_raw_fn)(void *iob);         // IoBuffer::raw()
+typedef int      (*iob_size_fn)(void *iob);        // IoBuffer::size()
+
+// ---- page protection helper ----
+bool set_prot(uintptr_t addr, size_t len, int prot)
+{
+    const uintptr_t ps   = (uintptr_t)sysconf(_SC_PAGESIZE);
+    const uintptr_t page = addr & ~(ps - 1);
+    const size_t    span = (addr + len) - page;
+    return mprotect(reinterpret_cast<void *>(page), span, prot) == 0;
+}
+
+// Read an inbound frame's raw protobuf via the IoBuffer accessors routeMessage
+// uses. Returns the buffer pointer (and its size via *size_out), or nullptr on
+// any failure. Read-only.
+const uint8_t *frame_bytes(const void *iobuf_ref, int *size_out)
+{
+    *size_out = 0;
+    if (!iobuf_ref) return nullptr;
+    void *iob = reinterpret_cast<sp_deref_fn>(kSharedPtrDeref)(iobuf_ref);
+    if (!iob) return nullptr;
+    const uint8_t *raw = reinterpret_cast<iob_raw_fn>(kIoBufferRaw)(iob);
+    int size = reinterpret_cast<iob_size_fn>(kIoBufferSize)(iob);
+    if (!raw || size <= 0) return nullptr;
+    *size_out = size;
+    return raw;
+}
+
+// ---- raw relay to the blmjciaapa HUD renderer ------------------------------
+// We do NOT parse the AA frames here — blmjciaapa decodes + renders them. This
+// shim just forwards the swallowed nav frames (an AaNav16Hdr + the raw frame
+// bytes) over an abstract AF_UNIX datagram socket. Fail-safe: any error
+// (including "receiver not bound yet") just drops the datagram; the next lands.
+int g_tx_fd = -1;
+
+void nav16_send_raw(const void *buf, size_t len)
+{
+    if (g_tx_fd < 0) {
+        g_tx_fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+        if (g_tx_fd < 0) { LOGE("nav16: socket() failed: %s", strerror(errno)); return; }
+    }
+    struct sockaddr_un addr;
+    socklen_t addrlen;
+    aa_nav16_fill_addr(addr, addrlen);
+
+    ssize_t n = sendto(g_tx_fd, buf, len, MSG_DONTWAIT,
+                       reinterpret_cast<struct sockaddr *>(&addr), addrlen);
+    if (n < 0) {
+        // ECONNREFUSED / ENOENT just means blmjciaapa's receiver isn't bound
+        // yet — normal during bring-up; the next frame will land.
+        LOGV("nav16: sendto dropped: %s", strerror(errno));
+    }
+}
+
+// Wrap one inbound AA nav frame in an AaNav16Hdr and relay it, raw. Read-only on
+// the IoBuffer; caps the payload at AA_NAV16_MAX_FRAME.
+void relay_frame(const void *iobuf_ref)
+{
+    int size = 0;
+    const uint8_t *raw = frame_bytes(iobuf_ref, &size);
+    if (!raw || size < 2) {
+        LOGV("nav16: relay skipped — no/short frame (size=%d)", size);
+        return;
+    }
+    if (size > AA_NAV16_MAX_FRAME) size = AA_NAV16_MAX_FRAME;
+
+    char buf[sizeof(AaNav16Hdr) + AA_NAV16_MAX_FRAME];
+    AaNav16Hdr hdr;
+    hdr.magic    = AA_NAV16_MAGIC;
+    hdr.version  = AA_NAV16_VERSION;
+    hdr.reserved = 0;
+    hdr.len      = (uint16_t)size;
+    std::memcpy(buf, &hdr, sizeof(hdr));
+    std::memcpy(buf + sizeof(hdr), raw, (size_t)size);
+    nav16_send_raw(buf, sizeof(hdr) + (size_t)size);
+}
+
+// Installed replacement for NavigationStatusEndpoint::routeMessage (we swapped
+// the vtable slot; the real body is untouched, so calling it stays safe and
+// non-recursive).
+//
+// The OEM endpoint returns -253 for any msgId outside {0x8003,0x8004,0x8005},
+// which MessageRouter turns into a {00 FF} frame -> AA teardown. So we SWALLOW
+// the whole GAL 1.6 nav range (0x8001..0x8007) by returning 0 ("handled"). This
+// stays a dumb pipe: every swallowed frame is relayed RAW and unfiltered, so the
+// receiver can start consuming more ids without ever re-touching this brick-PID
+// shim. (The receiver currently acts on 0x8002/0x8003/0x8006/0x8007.) Messages
+// outside the range are not ours — pass them to the real OEM routeMessage.
+int hook_routeMessage(void *self, uint32_t chan, uint32_t msgId, const void *iobuf_ref)
+{
+    const uint32_t id = msgId & 0xffff;
+    if (id >= AA_NAV16_MSG_SWALLOW_FIRST && id <= AA_NAV16_MSG_SWALLOW_LAST) {
+        LOGV("nav16: swallow msgId=0x%04x chan=%u -> relay", id, chan);
+        relay_frame(iobuf_ref);                     // catch -> forward raw -> return 0
+        return 0;                                   // routeMessage's "handled OK" value
+    }
+    return reinterpret_cast<route_fn>(kRouteMessageAddr)(self, chan, msgId, iobuf_ref);
+}
+
+// Patch the advertised GAL version 1.5 -> 1.6 (mov r2,#5 -> #6). Byte-verified.
+void bump_version()
+{
+    volatile uint32_t *p = reinterpret_cast<volatile uint32_t *>(kVersionInsnAddr);
+    if (*p != kVersionInsnOld) {
+        LOGE("version: ABORT — 0x%08x at 0x%08lx, expected 0x%08x (binary differs; not patching)",
+             *p, (unsigned long)kVersionInsnAddr, kVersionInsnOld);
+        return;
+    }
+    if (!set_prot(kVersionInsnAddr, 4, PROT_READ | PROT_WRITE)) {
+        LOGE("version: ABORT — mprotect RW failed");
+        return;
+    }
+    *p = kVersionInsnNew;
+    set_prot(kVersionInsnAddr, 4, PROT_READ | PROT_EXEC);
+    __builtin___clear_cache(reinterpret_cast<char *>(kVersionInsnAddr),
+                            reinterpret_cast<char *>(kVersionInsnAddr + 4));
+    LOGD("version: advertising GAL 1.6 (mov r2,#5 -> #6 @0x%08lx)",
+         (unsigned long)kVersionInsnAddr);
+}
+
+// Install the nav routeMessage hook by swapping the vtable slot. Byte-verified.
+// Returns true only if the hook was actually installed; false on byte-verify
+// mismatch or mprotect failure (caller must NOT bump the advertised version on
+// false — see aap_service_patch_init).
+bool install_nav_hook()
+{
+    volatile uintptr_t *slot = reinterpret_cast<volatile uintptr_t *>(kVtableSlotAddr);
+    if (*slot != kRouteMessageAddr) {
+        LOGE("hook: ABORT — vtable slot7 @0x%08lx = 0x%08lx, expected 0x%08lx "
+             "(binary differs; not hooking)",
+             (unsigned long)kVtableSlotAddr, (unsigned long)*slot,
+             (unsigned long)kRouteMessageAddr);
+        return false;
+    }
+    if (!set_prot(kVtableSlotAddr, sizeof(uintptr_t), PROT_READ | PROT_WRITE)) {
+        LOGE("hook: ABORT — mprotect RW failed on vtable");
+        return false;
+    }
+    *slot = reinterpret_cast<uintptr_t>(&hook_routeMessage);
+    LOGD("hook: nav routeMessage hook installed (slot7 @0x%08lx)",
+         (unsigned long)kVtableSlotAddr);
+    // Restore the vtable page to read-only (W^X hardening: it lives in
+    // .data.rel.ro and only needed to be writable for the swap above).
+    if (!set_prot(kVtableSlotAddr, sizeof(uintptr_t), PROT_READ))
+        LOGW("hook: mprotect RO restore failed (hook IS installed; continuing)");
+    return true;
+}
+
+__attribute__((constructor))
+void aap_service_patch_init()
+{
+    // This LD_PRELOAD is inherited by every process aap_service forks/execs; our
+    // patches dereference fixed aap_service addresses, so stay inert unless
+    // argv[0] is aap_service itself.
+    if (!preload_in_aap_service())
+        return;
+
+    libpatch_config::load(reinterpret_cast<const void *>(&aap_service_patch_init));
+
+    // The whole 1.6 path is opt-in on this one key. When hud is off nothing
+    // renders the relayed frames, but the hook still swallows the nav range so
+    // the AA session stays healthy — so gating here on use_protocol_v1_6 alone
+    // is safe.
+    if (!libpatch_config::use_protocol_v1_6()) {
+        LOGD("use_protocol_v1_6=false -> GAL 1.5 (stock); shim inert");
+        return;
+    }
+
+    LOGD("GAL 1.6 nav path active (pid=%d)", (int)getpid());
+    preload_install_fatal_handler();   // dump regs/maps on crash, then re-raise
+
+    // Transactional hook-first: install the vtable hook BEFORE advertising 1.6.
+    // If install_nav_hook() fails (binary mismatch or mprotect failure) the OEM
+    // 1.5 endpoint stays live; advertising 1.6 in that split-brain state would
+    // cause the phone to send 1.6 nav messages that the OEM endpoint returns -253
+    // for -> MessageRouter emits {00 FF} -> Android Auto tears down. By only
+    // bumping the version when the hook is confirmed installed, both operations
+    // are kept consistent: either the hook is live and we advertise 1.6, or
+    // neither fires and the unit speaks stock GAL 1.5.
+    if (install_nav_hook()) {
+        bump_version();
+    } else {
+        LOGE("GAL 1.6 path DISABLED — hook failed; staying stock GAL 1.5");
+    }
+}
+
+} // namespace

--- a/mazda/patches/blmjciaapa/hud/hud.cpp
+++ b/mazda/patches/blmjciaapa/hud/hud.cpp
@@ -24,6 +24,8 @@
 #include "svcnavi_tx.h"
 #include "vbs_tx.h"
 #include "translit.h"   // hud_translit::fold() — precomposed-Latin street-name fold
+#include "hud_nav16.h"  // 1.6 decoder + AaLane + aa_nav16_lane_bytes + aa_to_mazda_unit/parse_dist_x10
+#include "common/aa_nav16_msg.h"   // AA_NAV16_MSG_* — the sender/receiver msgId contract
 
 #include <stdint.h>
 #include <string.h>
@@ -42,15 +44,25 @@ struct HudTransportOps {
                       int32_t angle, int32_t number);
     void (*distance)(int32_t dist_m, int32_t time_s,
                      int32_t disp_dist, uint32_t disp_unit);
+    void (*guidance_v16)(uint32_t glyph, const char *road, int32_t dist_dec,
+                         uint8_t unit, const AaLane *lanes, uint8_t n);
 };
+
+// Forward to the vbs transport. Lanes are carried through (the vbs transport
+// holds them); see vbs_tx.cpp for the emit-side OEM-ABI note on the direct frame.
+void vbs_v16_adapter(uint32_t glyph, const char *road, int32_t dist_dec,
+                     uint8_t unit, const AaLane *lanes, uint8_t n)
+{
+    vbs_tx_v16(glyph, road, dist_dec, unit, lanes, n);
+}
 
 const HudTransportOps kSvcnaviOps = {
     &svcnavi_tx_start, &svcnavi_tx_stop, &svcnavi_tx_status,
-    &svcnavi_tx_next_turn, &svcnavi_tx_distance,
+    &svcnavi_tx_next_turn, &svcnavi_tx_distance, &svcnavi_tx_v16,
 };
 const HudTransportOps kVbsOps = {
     &vbs_tx_start, &vbs_tx_stop, &vbs_tx_status,
-    &vbs_tx_next_turn, &vbs_tx_distance,
+    &vbs_tx_next_turn, &vbs_tx_distance, &vbs_v16_adapter,
 };
 
 // The active backend. Bound once in hud_tx_start() (the first transport
@@ -66,6 +78,11 @@ inline void hud_tx_start()
     g_tx->start();
 }
 inline void hud_tx_stop()   { g_tx->stop(); }
+// NOTE: the single-writer invariant is enforced at the producer ENTRY points,
+// not on these shared forwarders — our_nav_cb (1.5) returns early once 1.6
+// frames are actually arriving (hud_nav16_rx_seen), and the 1.6 path's only
+// writer is the rx thread (which only runs under v1.6).
+// hud_tx_status is intentionally NOT guarded: the 1.6 CLEAR path calls it.
 inline void hud_tx_status(uint32_t status) { g_tx->status(status); }
 inline void hud_tx_next_turn(const char *road, uint32_t side, uint32_t event,
                              int32_t angle, int32_t number)
@@ -73,7 +90,7 @@ inline void hud_tx_next_turn(const char *road, uint32_t side, uint32_t event,
     // Fold HUD-unrenderable precomposed Latin letters (Latin Extended
     // Additional, U+1E00..U+1EFF) down to their base forms so accented
     // street names show legibly instead of gapping (gated by
-    // hud_fold_latin, default on). Copy the SDK-owned (const) road name
+    // hud_fold_latin, default off). Copy the SDK-owned (const) road name
     // into a local buffer first, then fold in place — the fold only ever
     // shrinks, so 256 bounds it (the transports truncate to their own
     // buffer anyway).
@@ -90,6 +107,23 @@ inline void hud_tx_next_turn(const char *road, uint32_t side, uint32_t event,
 inline void hud_tx_distance(int32_t dist_m, int32_t time_s,
                             int32_t disp_dist, uint32_t disp_unit)
 { g_tx->distance(dist_m, time_s, disp_dist, disp_unit); }
+
+// GAL 1.6 guidance forwarder. Unlike hud_tx_next_turn, no fold here: the road
+// arrives ALREADY folded — hud_feed_nav16_raw folds once at 0x8006 ingest, so
+// the per-tick distance emits (every 0x8007 on final approach) do zero string
+// work on the rx thread.
+inline void hud_tx_guidance_v16(uint32_t glyph, const char *road, int32_t dist_dec,
+                                uint8_t unit, const AaLane *lanes, uint8_t n)
+{
+    // Single-writer guard: 1.5 cb thread owns g_snapshot in v1.5 mode. The rx
+    // thread only runs under v1.6, so this should never fire — log it if it
+    // somehow does (config changed under us) rather than dropping silently.
+    if (!libpatch_config::use_protocol_v1_6()) {
+        LOGV("hud_tx_guidance_v16: dropped — use_protocol_v1_6 not set");
+        return;
+    }
+    g_tx->guidance_v16(glyph, road, dist_dec, unit, lanes, n);
+}
 
 // cb_list shape: 19 word slots, total 76 bytes. The SDK memcpy's
 // all 76 bytes into the session handle at handle+0x20 inside
@@ -413,6 +447,18 @@ void our_nav_cb(void *user_ctx, void *hdr36)
         return;
     }
 
+    // Single-writer guard + 1.5 fallback: drop the legacy 0x500/0x501/0x502
+    // callbacks only once 1.6 frames are actually arriving on the rx socket —
+    // NOT on the config flag. aap_service (which advertises 1.6) and this
+    // process share only the config key, not the negotiated session, so with
+    // the flag set but the 1.6 chain broken (shim not preloaded, byte-verify
+    // aborted, phone declined) the phone keeps speaking 1.5 and these
+    // callbacks are the only guidance there is — dropping them would leave
+    // the HUD dark. A session speaks one protocol, so the two snapshot
+    // writers still never race (the seqlock is SPSC); the latch just picks
+    // the producer per session.
+    if (hud_nav16_rx_seen()) return;
+
     const uint32_t tag = *static_cast<const uint32_t *>(hdr36);
     switch (tag) {
     case kTagStatus: {
@@ -496,12 +542,165 @@ void hud_pre_aap_create_session(void *cb_list)
                   "user-context slot out of cb_list bounds");
 }
 
+// NavigationStatus (0x8003) enum (aasdk): UNAVAILABLE=0, ACTIVE=1, INACTIVE=2,
+// REROUTING=3. INACTIVE/UNAVAILABLE -> blank the HUD; ACTIVE/REROUTING -> keep.
+enum { NAV_UNAVAILABLE = 0, NAV_ACTIVE = 1, NAV_INACTIVE = 2, NAV_REROUTING = 3 };
+
+// Quantize the display distance (value*10) to its natural on-HUD granularity, so
+// a frame is only re-sent when the SHOWN figure would change — not on every
+// position tick. mi/km are already 0.1-granular; m/yd/ft step by magnitude.
+int32_t quantize_dist_x10(int32_t v, uint8_t mazda_unit)
+{
+    if (v < 0) return 0;
+    if (mazda_unit == 2 || mazda_unit == 3) return v;        // mi/km: 0.1 already
+    if (v >= 5000) return (v + 250) / 500 * 500;             // far  -> 50-unit steps
+    if (v >= 1000) return (v +  50) / 100 * 100;             // mid  -> 10-unit steps
+    if (v >=  200) return (v +  25) /  50 *  50;             // near ->  5-unit steps
+    return v;                                                // final approach -> as-is
+}
+
+// Accumulated Mazda-domain guidance: maneuver/road/lanes come from 0x8006,
+// distance from 0x8007, so the two streams are merged here before display. Laid
+// out gap-free (and zero-initialised as a static) so the memcmp change-gate is
+// exact — KEEP IT GAP-FREE if you add a field.
+struct AaNav16HudState {
+    uint32_t glyph;                       // Mazda HUD maneuver glyph (MazdaIcon; 0=blank)
+    int32_t  dist_dec;                    // display distance * 10
+    uint8_t  dist_unit;                   // Mazda HUD unit 0..5
+    uint8_t  n_lanes;                     // 0..HUD_NAV16_MAX_LANES
+    uint8_t  pad0, pad1;                  // keep gap-free for the memcmp change-gate
+    char     road[64];                    // street name (UTF-8, folded at 0x8006 ingest)
+    AaLane   lanes[HUD_NAV16_MAX_LANES];
+};
+static_assert(sizeof(AaNav16HudState) == 108,
+              "AaNav16HudState must stay gap-free (memcmp change-gate)");
+
+static AaNav16HudState g_nav16_acc;   // merged guidance (zero-init: gap-free memcmp)
+static AaNav16HudState g_nav16_last;  // last frame fed to the transport (change-gate)
+static bool g_nav16_have_last = false;
+
+// Reset the accumulator + change-gate. Owned by the rx lifecycle: called from
+// hud_nav16_rx_start() BEFORE the receiver thread exists (the only other
+// toucher of this state), so it needs no locking. Without this, a session that
+// ends abnormally (cable pull — the phone never sends INACTIVE/STOP) leaves a
+// stale change-gate that can suppress the next session's first frame against
+// an already-blanked HUD.
+void hud_feed_nav16_reset(void)
+{
+    memset(&g_nav16_acc, 0, sizeof(g_nav16_acc));
+    g_nav16_have_last = false;
+    LOGV("nav: accumulator + change-gate reset");
+}
+
+// Render a RAW GAL 1.6 nav frame relayed from the aap_service shim (runs on the
+// nav16 receiver thread). This is the SINGLE place that decodes the AA protocol
+// and maps it to the Mazda HUD domain: 0x8006 -> maneuver/road/lanes, 0x8007 ->
+// distance, 0x8003 -> lifecycle, 0x8002 -> blank. Decoded guidance goes through
+// the shared transport (glyph + fold + lanes), reusing the existing renderer.
+void hud_feed_nav16_raw(const uint8_t *frame, int len)
+{
+    if (!frame || len < 2) return;
+
+    AaNav16HudState &acc  = g_nav16_acc;
+    AaNav16HudState &last = g_nav16_last;
+    bool &have_last       = g_nav16_have_last;
+
+    // Change-gate: only feed the transport when the displayed frame changed. The
+    // svcnavi transport has no consumer-side diff, so this is what prevents a
+    // duplicate/continuous-tick flood on the HUD D-Bus.
+    auto emit_if_changed = [&]() {
+        if (have_last && memcmp(&acc, &last, sizeof(acc)) == 0) return;
+        hud_tx_guidance_v16(acc.glyph, acc.road, acc.dist_dec, acc.dist_unit,
+                            acc.lanes, acc.n_lanes);
+        last = acc;
+        have_last = true;
+    };
+
+    const uint32_t id = ((uint32_t)frame[0] << 8) | frame[1];
+
+    if (id == AA_NAV16_MSG_NAV_STATE) {  // maneuver + road + lanes
+        AaGuidance g;
+        hud_nav16_on_frame(frame, len, &g, nullptr);
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+        char line[320]; hud_nav16_format_guidance(&g, line, sizeof(line)); LOGV("%s", line);
+#endif
+        uint32_t glyph = hud_nav16_glyph(&g);
+        if (glyph > 60) glyph = 0;                         // clamp untrusted glyph
+        // Fold once here, at road ingest, not in the per-emit forwarder —
+        // distance ticks re-emit the road far more often than 0x8006 changes
+        // it. Folding g.road (our stack copy) BEFORE the strncpy matters: the
+        // fold shrinks in place without clearing its residue, and the gap-free
+        // memcmp change-gate needs acc.road's tail zero-padded — which strncpy
+        // does when the source is already its final length.
+        if (libpatch_config::hud_fold_latin()) {
+            hud_translit::fold(g.road);
+        }
+        // A different maneuver means the held distance belongs to the PREVIOUS
+        // step (distance only ever arrives on 0x8007) — invalidate it so the
+        // new arrow is never shown against the old step's ticking-down figure.
+        // 0 + unit 0 ("none") is the same not-yet-any-distance state every
+        // session starts in; the real figure lands with the next 0x8007 (~1 s).
+        if (glyph != acc.glyph || strcmp(g.road, acc.road) != 0) {
+            acc.dist_dec  = 0;
+            acc.dist_unit = 0;
+        }
+        acc.glyph = glyph;
+        strncpy(acc.road, g.road, sizeof(acc.road) - 1);
+        acc.road[sizeof(acc.road) - 1] = '\0';
+        int nl = g.n_lanes;
+        if (nl < 0) nl = 0;
+        if (nl > HUD_NAV16_MAX_LANES) nl = HUD_NAV16_MAX_LANES;
+        acc.n_lanes = (uint8_t)nl;
+        for (int i = 0; i < HUD_NAV16_MAX_LANES; ++i) {
+            acc.lanes[i].present_mask   = (i < nl) ? g.lanes[i].present_mask   : 0;
+            acc.lanes[i].highlight_mask = (i < nl) ? g.lanes[i].highlight_mask : 0;
+        }
+        emit_if_changed();
+    } else if (id == AA_NAV16_MSG_POSITION) {      // distance to next maneuver
+        AaPosition p;
+        hud_nav16_on_frame(frame, len, nullptr, &p);
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+        char line[320]; hud_nav16_format_position(&p, line, sizeof(line)); LOGV("%s", line);
+#endif
+        if (p.have_step) {
+            uint8_t unit = aa_to_mazda_unit(p.step_units);
+            if (unit > 5) unit = 0;                        // clamp untrusted unit
+            acc.dist_unit = unit;
+            acc.dist_dec  = quantize_dist_x10(parse_dist_x10(p.step_display), unit);
+            emit_if_changed();
+        }
+    } else if (id == AA_NAV16_MSG_STATUS) {        // lifecycle
+        int status = -1;
+        hud_nav16_read_status(frame, len, &status);
+        if (status == NAV_INACTIVE || status == NAV_UNAVAILABLE) {
+            hud_tx_status(2);                              // guidance ended -> blank
+            hud_feed_nav16_reset();
+            LOGD("nav: NavigationStatus=%d -> HUD cleared", status);
+        } else {
+            LOGV("nav: NavigationStatus=%d (active/rerouting) -> HUD kept", status);
+        }
+    } else if (id == AA_NAV16_MSG_CLUSTER_STOP) {
+        hud_tx_status(2);
+        hud_feed_nav16_reset();
+        LOGD("nav: cluster STOP (0x8002) -> HUD cleared");
+    }
+    // CLUSTER_START / NEXT_TURN / NEXT_TURN_DIST: nothing to render
+}
+
 void hud_post_aap_create_session(void)
 {
     hud_tx_start();
+    // Start the GAL 1.6 receiver only when that protocol is enabled — otherwise
+    // the aap_service shim never sends and the socket would idle for nothing.
+    if (libpatch_config::use_protocol_v1_6()) {
+        hud_nav16_rx_start();
+    }
 }
 
 void hud_pre_aap_destroy_session(void)
 {
+    if (libpatch_config::use_protocol_v1_6()) {
+        hud_nav16_rx_stop();
+    }
     hud_tx_stop();
 }

--- a/mazda/patches/blmjciaapa/hud/hud.h
+++ b/mazda/patches/blmjciaapa/hud/hud.h
@@ -5,6 +5,8 @@
 #ifndef LIBPATCH_BLMJCIAAPA_HUD_HUD_H
 #define LIBPATCH_BLMJCIAAPA_HUD_HUD_H
 
+#include <stdint.h>
+
 // Defined in hud.cpp. Called from the aap_create_session PLT shim
 // BEFORE chaining to the real SDK entry point, to substitute the
 // (NULL on OEM) navigation callback slot in cb_list with one that
@@ -19,5 +21,39 @@ void hud_post_aap_create_session(void);
 // Defined in hud.cpp. Called before the real aap_destroy_session to
 // stop the HUD sender side.
 void hud_pre_aap_destroy_session(void);
+
+// === Android Auto GAL 1.6 path ================================
+//
+// The aap_service shim (a SEPARATE process) swallows the 1.6 navigation frames
+// and relays them RAW over an abstract AF_UNIX datagram socket. The receiver
+// thread (nav16_rx.cpp) hands each raw frame to hud_feed_nav16_raw(), which is
+// the single place that decodes the AA protocol, maps it to the Mazda HUD
+// domain, and renders it through the SAME transport (glyph emit, street fold,
+// lanes) the 1.5 path uses.
+
+// Defined in hud.cpp. Decode + render one raw GAL 1.6 nav frame (full frame,
+// leading 2-byte big-endian msgId). Runs on the nav16 receiver thread.
+void hud_feed_nav16_raw(const uint8_t *frame, int len);
+
+// Defined in hud.cpp. Reset hud_feed_nav16_raw's accumulator + change-gate.
+// Called from hud_nav16_rx_start() while the receiver thread is NOT running
+// (it is the only other toucher of that state), so a session that ended
+// abnormally — cable pull, no INACTIVE/STOP received — can't leave a stale
+// gate that suppresses the next session's first frame.
+void hud_feed_nav16_reset(void);
+
+// Defined in nav16_rx.cpp. Start/stop the receiver thread + socket. Started
+// from hud_post_aap_create_session when use_protocol_v1_6 is set, stopped from
+// hud_pre_aap_destroy_session. Both idempotent.
+void hud_nav16_rx_start(void);
+void hud_nav16_rx_stop(void);
+
+// Defined in nav16_rx.cpp. TRUE once a validated 1.6 frame has arrived on the
+// rx socket this session (reset by hud_nav16_rx_start). our_nav_cb keys the
+// legacy-1.5-callback drop on THIS — evidence the 1.6 chain really took — not
+// on the config flag, so a 1.6 setup that didn't take (aap_service shim not
+// preloaded / byte-verify aborted / phone declined the advertisement) falls
+// back to the stock 1.5 path instead of leaving the HUD dark.
+bool hud_nav16_rx_seen(void);
 
 #endif // LIBPATCH_BLMJCIAAPA_HUD_HUD_H

--- a/mazda/patches/blmjciaapa/hud/hud_nav.h
+++ b/mazda/patches/blmjciaapa/hud/hud_nav.h
@@ -28,6 +28,7 @@
 // into the ECU firmware and is out of our scope. Same numbering
 // as the reference, no remapping.
 enum MazdaIcon : uint8_t {
+    HUD_BLANK              = 0,    // HUD draws nothing (implicit blank; named for the 1.6 map)
     HUD_STRAIGHT            = 1,
     HUD_LEFT                = 2,
     HUD_RIGHT               = 3,
@@ -61,6 +62,12 @@ enum MazdaIcon : uint8_t {
     HUD_DESTINATION_RIGHT   = 34,
     HUD_FLAG_LEFT           = 35,
     HUD_FLAG_RIGHT          = 36,
+    // Roundabout exit-glyph bases (12 directional glyphs per traffic side); the
+    // exit angle is added in roundabout_icon()/the 1.6 roundabout map. Named here
+    // so the 1.6 glyph map has a single source for them (1.5 roundabout_icon below
+    // uses the same 37/49 offsets).
+    HUD_ROUNDABOUT_CCW_BASE = 37,   // right-hand traffic, +round(angle/30) -> 37..48
+    HUD_ROUNDABOUT_CW_BASE  = 49,   // left-hand  traffic, +round(angle/30) -> 49..60
 };
 
 // === Android turn_event → Mazda icon ==========================

--- a/mazda/patches/blmjciaapa/hud/hud_nav16.cpp
+++ b/mazda/patches/blmjciaapa/hud/hud_nav16.cpp
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Adapted from headunit (https://github.com/Trevelopment/headunit),
+// licensed under GNU AGPL v3.
+// See NOTICE.md at the repo root for the full attribution.
+//
+// hud_nav16 — AA GAL 1.6 NavigationState/CurrentPosition decoder + HUD glyph
+// map. See header. Pure, bounds-checked; no I/O. Host self-test lives in
+// test/nav16_test.cpp (wired into test/Makefile).
+
+#include "hud_nav16.h"
+#include "hud_nav.h"   // MazdaIcon glyph IDs (HUD_*) — one enum, shared with the 1.5 path
+#include "common/aa_nav16_msg.h"   // AA_NAV16_MSG_* — the sender/receiver msgId contract
+
+#include <cstring>
+#include <cstdio>
+
+namespace {
+
+// ---- minimal, bounds-checked protobuf reader --------------------------------
+struct Pb { const uint8_t *p; const uint8_t *end; };
+
+bool rd_varint(Pb &c, uint64_t &v)
+{
+    v = 0; int shift = 0;
+    while (c.p < c.end && shift < 64) {
+        uint8_t b = *c.p++;
+        v |= (uint64_t)(b & 0x7f) << shift;
+        if (!(b & 0x80)) return true;
+        shift += 7;
+    }
+    return false;   // truncated or overlong
+}
+
+bool rd_tag(Pb &c, uint32_t &field, uint32_t &wire)
+{
+    if (c.p >= c.end) return false;
+    uint64_t t;
+    if (!rd_varint(c, t)) return false;
+    field = (uint32_t)(t >> 3);
+    wire  = (uint32_t)(t & 7);
+    return true;
+}
+
+// length-delimited: yields a view [data, data+len) and advances past it.
+bool rd_bytes(Pb &c, const uint8_t *&data, size_t &len)
+{
+    uint64_t l;
+    if (!rd_varint(c, l)) return false;
+    if ((uint64_t)(c.end - c.p) < l) return false;   // would overrun
+    data = c.p; len = (size_t)l; c.p += l;
+    return true;
+}
+
+bool skip(Pb &c, uint32_t wire)
+{
+    uint64_t v; const uint8_t *d; size_t l;
+    switch (wire) {
+        case 0: return rd_varint(c, v);                                   // varint
+        case 1: if (c.end - c.p < 8) return false; c.p += 8; return true; // 64-bit
+        case 2: return rd_bytes(c, d, l);                                 // len-delimited
+        case 5: if (c.end - c.p < 4) return false; c.p += 4; return true; // 32-bit
+        default: return false;                                            // groups: unexpected
+    }
+}
+
+void copy_str(char *dst, size_t cap, const uint8_t *s, size_t n)
+{
+    if (cap == 0) return;
+    if (n >= cap) n = cap - 1;
+    std::memcpy(dst, s, n);
+    dst[n] = '\0';
+}
+
+// ---- NavigationDistance { meters=1, display_value=2, display_units=3 } -------
+void dec_distance(const uint8_t *b, size_t n,
+                  int32_t &meters, char *disp, size_t disp_cap, uint32_t &units)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; meters = (int32_t)v; }
+        else if (f == 2 && w == 2) { const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break; copy_str(disp, disp_cap, d, l); }
+        else if (f == 3 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; units = (uint32_t)v; }
+        else if (!skip(c, w)) break;
+    }
+}
+
+// ---- NavigationRoad { name=1 string } : copy name out -----------------------
+void dec_road_name(const uint8_t *b, size_t n, char *dst, size_t cap)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) { const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break; copy_str(dst, cap, d, l); }
+        else if (!skip(c, w)) break;
+    }
+}
+
+// ---- LaneDirection { shape=1, is_highlighted=2 } ----------------------------
+void dec_lane_direction(const uint8_t *b, size_t n, AaLane &lane)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    uint64_t shape = 0; bool have_shape = false, hi = false;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; shape = v; have_shape = true; }
+        else if (f == 2 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; hi = (v != 0); }
+        else if (!skip(c, w)) break;
+    }
+    if (have_shape && shape <= 9) {
+        lane.present_mask |= (uint16_t)(1u << shape);
+        if (hi) lane.highlight_mask |= (uint16_t)(1u << shape);
+    }
+}
+
+// ---- NavigationLane { repeated LaneDirection lane_directions=1 } -------------
+void dec_lane(const uint8_t *b, size_t n, AaLane &lane)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) { const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break; dec_lane_direction(d, l, lane); }
+        else if (!skip(c, w)) break;
+    }
+}
+
+// ---- NavigationManeuver { type=1, roundabout_exit_number=2, _exit_angle=3 } --
+void dec_maneuver(const uint8_t *b, size_t n, AaGuidance &g)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; g.maneuver_type = (uint32_t)v; g.have_maneuver = true; }
+        else if (f == 2 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; g.roundabout_exit_number = (int32_t)v; }
+        else if (f == 3 && w == 0) { uint64_t v; if (!rd_varint(c, v)) break; g.roundabout_exit_angle = (int32_t)v; }
+        else if (!skip(c, w)) break;
+    }
+}
+
+// ---- NavigationStep { maneuver=1, road=2, lanes=3 (rep), cue=4 } -------------
+void dec_step(const uint8_t *b, size_t n, AaGuidance &g)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (w == 2) {
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break;
+            if      (f == 1) dec_maneuver(d, l, g);
+            else if (f == 2) dec_road_name(d, l, g.road, sizeof(g.road));
+            else if (f == 3) {
+                if (g.n_lanes < HUD_NAV16_MAX_LANES) {
+                    dec_lane(d, l, g.lanes[g.n_lanes]);
+                    g.n_lanes++;
+                }
+            }
+            // f == 4 (cue): redundant with road for the HUD strip — skip.
+        } else if (!skip(c, w)) break;
+    }
+}
+
+// ---- NavigationStepDistance { distance=1, time_to_step_seconds=2 } -----------
+void dec_step_distance(const uint8_t *b, size_t n, AaPosition &p)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) {
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break;
+            dec_distance(d, l, p.step_meters, p.step_display, sizeof(p.step_display), p.step_units);
+            p.have_step = true;
+        } else if (!skip(c, w)) break;
+    }
+}
+
+// ---- NavigationDestinationDistance { distance=1, eta=2, ttl_seconds=3 } ------
+void dec_dest_distance(const uint8_t *b, size_t n, AaPosition &p)
+{
+    Pb c{b, b + n}; uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) {
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break;
+            dec_distance(d, l, p.dest_meters, p.dest_display, sizeof(p.dest_display), p.dest_units);
+            p.have_dest = true;
+        } else if (f == 2 && w == 2) {
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break; copy_str(p.eta, sizeof(p.eta), d, l);
+        } else if (!skip(c, w)) break;
+    }
+}
+
+const char *kManeuver[] = {
+    "UNKNOWN","DEPART","NAME_CHANGE","KEEP_LEFT","KEEP_RIGHT","TURN_SLIGHT_LEFT",
+    "TURN_SLIGHT_RIGHT","TURN_NORMAL_LEFT","TURN_NORMAL_RIGHT","TURN_SHARP_LEFT",
+    "TURN_SHARP_RIGHT","U_TURN_LEFT","U_TURN_RIGHT","ON_RAMP_SLIGHT_LEFT",
+    "ON_RAMP_SLIGHT_RIGHT","ON_RAMP_NORMAL_LEFT","ON_RAMP_NORMAL_RIGHT",
+    "ON_RAMP_SHARP_LEFT","ON_RAMP_SHARP_RIGHT","ON_RAMP_U_TURN_LEFT",
+    "ON_RAMP_U_TURN_RIGHT","OFF_RAMP_SLIGHT_LEFT","OFF_RAMP_SLIGHT_RIGHT",
+    "OFF_RAMP_NORMAL_LEFT","OFF_RAMP_NORMAL_RIGHT","FORK_LEFT","FORK_RIGHT",
+    "MERGE_LEFT","MERGE_RIGHT","MERGE_SIDE_UNSPECIFIED","ROUNDABOUT_ENTER",
+    "ROUNDABOUT_EXIT","RA_ENTER_EXIT_CW","RA_ENTER_EXIT_CW_ANGLE","RA_ENTER_EXIT_CCW",
+    "RA_ENTER_EXIT_CCW_ANGLE","STRAIGHT","FERRY_BOAT","FERRY_TRAIN","DESTINATION",
+    "DESTINATION_STRAIGHT","DESTINATION_LEFT","DESTINATION_RIGHT",
+};
+const char *kShape[] = {
+    "UNK","STRAIGHT","SLIGHT_L","SLIGHT_R","NORMAL_L","NORMAL_R",
+    "SHARP_L","SHARP_R","UTURN_L","UTURN_R",
+};
+
+// AA NavigationType (0..42) -> Mazda HUD glyph. Values cross-referenced to the
+// MazdaIcon 1.5 glyph atlas in hud_nav.h (the road-validated reference table);
+// KEEP_LEFT/RIGHT are FORK glyphs (NNG-confirmed). On-ramps reuse the turn
+// glyphs by severity/side (no dedicated on-ramp glyph). Roundabout ENTER_AND_EXIT
+// (32..35) are resolved by exit angle in hud_nav16_glyph(), NOT from this table;
+// the entries here are unused fallbacks.
+const uint8_t kManeuverGlyph[43] = {
+    /* 0  UNKNOWN                */ HUD_EMPTY,
+    /* 1  DEPART                 */ HUD_FLAG,
+    /* 2  NAME_CHANGE            */ HUD_STRAIGHT,
+    /* 3  KEEP_LEFT              */ HUD_FORK_LEFT,
+    /* 4  KEEP_RIGHT             */ HUD_FORK_RIGHT,
+    /* 5  TURN_SLIGHT_LEFT       */ HUD_SLIGHT_LEFT,
+    /* 6  TURN_SLIGHT_RIGHT      */ HUD_SLIGHT_RIGHT,
+    /* 7  TURN_NORMAL_LEFT       */ HUD_LEFT,
+    /* 8  TURN_NORMAL_RIGHT      */ HUD_RIGHT,
+    /* 9  TURN_SHARP_LEFT        */ HUD_SHARP_LEFT,
+    /* 10 TURN_SHARP_RIGHT       */ HUD_SHARP_RIGHT,
+    /* 11 U_TURN_LEFT            */ HUD_U_TURN_LEFT,
+    /* 12 U_TURN_RIGHT           */ HUD_U_TURN_RIGHT,
+    /* 13 ON_RAMP_SLIGHT_LEFT    */ HUD_SLIGHT_LEFT,
+    /* 14 ON_RAMP_SLIGHT_RIGHT   */ HUD_SLIGHT_RIGHT,
+    /* 15 ON_RAMP_NORMAL_LEFT    */ HUD_LEFT,
+    /* 16 ON_RAMP_NORMAL_RIGHT   */ HUD_RIGHT,
+    /* 17 ON_RAMP_SHARP_LEFT     */ HUD_SHARP_LEFT,
+    /* 18 ON_RAMP_SHARP_RIGHT    */ HUD_SHARP_RIGHT,
+    /* 19 ON_RAMP_U_TURN_LEFT    */ HUD_U_TURN_LEFT,
+    /* 20 ON_RAMP_U_TURN_RIGHT   */ HUD_U_TURN_RIGHT,
+    /* 21 OFF_RAMP_SLIGHT_LEFT   */ HUD_OFF_RAMP_LEFT,
+    /* 22 OFF_RAMP_SLIGHT_RIGHT  */ HUD_OFF_RAMP_RIGHT,
+    /* 23 OFF_RAMP_NORMAL_LEFT   */ HUD_OFF_RAMP_LEFT,
+    /* 24 OFF_RAMP_NORMAL_RIGHT  */ HUD_OFF_RAMP_RIGHT,
+    /* 25 FORK_LEFT              */ HUD_FORK_LEFT,
+    /* 26 FORK_RIGHT             */ HUD_FORK_RIGHT,
+    /* 27 MERGE_LEFT             */ HUD_MERGE_LEFT,
+    /* 28 MERGE_RIGHT            */ HUD_MERGE_RIGHT,
+    /* 29 MERGE_SIDE_UNSPECIFIED */ HUD_STRAIGHT,
+    /* 30 ROUNDABOUT_ENTER       */ HUD_STRAIGHT,   // no angle -> generic (OEM has no plain roundabout glyph)
+    /* 31 ROUNDABOUT_EXIT        */ HUD_STRAIGHT,
+    /* 32 RA_ENTER_EXIT_CW       */ HUD_STRAIGHT,   // resolved by angle in hud_nav16_glyph()
+    /* 33 RA_ENTER_EXIT_CW_ANGLE */ HUD_STRAIGHT,
+    /* 34 RA_ENTER_EXIT_CCW      */ HUD_STRAIGHT,
+    /* 35 RA_ENTER_EXIT_CCW_ANG  */ HUD_STRAIGHT,
+    /* 36 STRAIGHT               */ HUD_STRAIGHT,
+    /* 37 FERRY_BOAT             */ HUD_EMPTY,       // no glyph
+    /* 38 FERRY_TRAIN            */ HUD_EMPTY,
+    /* 39 DESTINATION            */ HUD_DESTINATION,
+    /* 40 DESTINATION_STRAIGHT   */ HUD_DESTINATION,
+    /* 41 DESTINATION_LEFT       */ HUD_DESTINATION_LEFT,
+    /* 42 DESTINATION_RIGHT      */ HUD_DESTINATION_RIGHT,
+};
+
+// Roundabout exit glyph by angle. The Mazda HUD ECU has 12 directional glyphs
+// per traffic side: right-hand traffic (CCW exits) 37..48, left-hand (CW) 49..60.
+// id = base + round(angle/30) mod 12. (Formula from hud_nav.h roundabout_icon.)
+uint8_t roundabout_glyph(int32_t exit_angle, bool clockwise)
+{
+    int a = exit_angle % 360; if (a < 0) a += 360;
+    int idx = ((a + 15) / 30) % 12;                       // 0..11
+    return (uint8_t)((clockwise ? HUD_ROUNDABOUT_CW_BASE
+                                : HUD_ROUNDABOUT_CCW_BASE) + idx);
+}
+
+} // namespace
+
+const char *hud_nav16_maneuver_name(uint32_t t)
+{
+    return (t < sizeof(kManeuver)/sizeof(kManeuver[0])) ? kManeuver[t] : "?";
+}
+const char *hud_nav16_shape_name(int s)
+{
+    return (s >= 0 && s < (int)(sizeof(kShape)/sizeof(kShape[0]))) ? kShape[s] : "?";
+}
+
+uint8_t hud_nav16_glyph(const AaGuidance *g)
+{
+    if (!g) return HUD_BLANK;
+    switch (g->maneuver_type) {
+        case 32: case 33:  // RA_ENTER_EXIT_CW (clockwise = left-hand traffic)
+            return roundabout_glyph(g->roundabout_exit_angle, /*clockwise=*/true);
+        case 34: case 35:  // RA_ENTER_EXIT_CCW (counterclockwise = right-hand traffic)
+            return roundabout_glyph(g->roundabout_exit_angle, /*clockwise=*/false);
+        default:
+            return (g->maneuver_type < 43) ? kManeuverGlyph[g->maneuver_type] : HUD_EMPTY;
+    }
+}
+
+// AA NavigationDistance.DistanceUnits (0..7) -> Mazda HUD unit
+// (1=m, 2=mi, 3=km, 4=yd, 5=ft).
+uint8_t aa_to_mazda_unit(uint32_t u)
+{
+    switch (u) {
+        case 1: return 1;          // METERS
+        case 2: case 3: return 3;  // KILOMETERS / KILOMETERS_P1
+        case 4: case 5: return 2;  // MILES / MILES_P1
+        case 6: return 5;          // FEET
+        case 7: return 4;          // YARDS
+        default: return 0;         // unknown -> HUD renders no unit
+    }
+}
+
+// Parse the AA display value ("350", "1,3", "1.3") to the HUD's value*10 form
+// (one decimal): "350" -> 3500, "1,3" -> 13. Returns 0 on garbage.
+int32_t parse_dist_x10(const char *s)
+{
+    if (!s) return 0;
+    long ip = 0; int frac = 0; bool sep = false, any = false;
+    for (const char *p = s; *p; ++p) {
+        if (*p >= '0' && *p <= '9') {
+            if (!sep) {
+                // Cap accumulation to prevent signed-overflow UB on ARM32 (long=32-bit);
+                // realistic distances are tiny, so this only fires on hostile input.
+                if (ip < 100000000L) ip = ip * 10 + (*p - '0');
+                any = true;
+            } else { frac = *p - '0'; break; }   // first fractional digit only
+        } else if (*p == ',' || *p == '.') {
+            sep = true;
+        }
+    }
+    return any ? (int32_t)(ip * 10 + frac) : 0;
+}
+
+bool hud_nav16_decode_navstate(const uint8_t *proto, int len, AaGuidance *out)
+{
+    if (!out) return false;
+    std::memset(out, 0, sizeof(*out));
+    if (!proto || len < 0) return false;
+    Pb c{proto, proto + len}; uint32_t f, w; bool got_step = false;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) {                 // repeated NavigationStep steps
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break;
+            out->n_steps++;
+            if (!got_step) { dec_step(d, l, *out); got_step = true; }   // step[0] = next maneuver
+        } else if (!skip(c, w)) break;          // destinations(2) etc. ignored for the HUD
+    }
+    return true;
+}
+
+bool hud_nav16_decode_position(const uint8_t *proto, int len, AaPosition *out)
+{
+    if (!out) return false;
+    std::memset(out, 0, sizeof(*out));
+    if (!proto || len < 0) return false;
+    Pb c{proto, proto + len}; uint32_t f, w; bool got_dest = false;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 2) {                 // step_distance
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break; dec_step_distance(d, l, *out);
+        } else if (f == 2 && w == 2) {          // repeated destination_distances (use first)
+            const uint8_t *d; size_t l; if (!rd_bytes(c, d, l)) break;
+            if (!got_dest) { dec_dest_distance(d, l, *out); got_dest = true; }
+        } else if (!skip(c, w)) break;          // current_road(3) ignored
+    }
+    return true;
+}
+
+uint32_t hud_nav16_on_frame(const uint8_t *raw, int size, AaGuidance *g, AaPosition *p)
+{
+    if (!raw || size < 2) return 0;
+    uint32_t id = ((uint32_t)raw[0] << 8) | raw[1];   // big-endian msgId
+    const uint8_t *body = raw + 2; int blen = size - 2;
+    if (id == AA_NAV16_MSG_NAV_STATE && g) hud_nav16_decode_navstate(body, blen, g);
+    else if (id == AA_NAV16_MSG_POSITION && p) hud_nav16_decode_position(body, blen, p);
+    return id;
+}
+
+// Read NavigationStatus (0x8003) field 1 (status enum varint) from a full frame
+// (leading 2-byte big-endian msgId). Returns true and sets *status_out if found.
+// Fully bounds-checked: uses the same Pb/rd_tag/rd_varint/skip reader as the
+// other decoders — no hand-rolled walk, no attacker-controlled pointer arithmetic.
+// *status_out is initialised to -1 (sentinel) up front; caller sees -1 if the
+// field is absent or the frame is truncated/malformed.
+bool hud_nav16_read_status(const uint8_t *raw, int size, int *status_out)
+{
+    if (status_out) *status_out = -1;
+    if (!raw || size < 2 || !status_out) return false;
+    // skip the 2-byte big-endian msgId, walk the protobuf body
+    Pb c{raw + 2, raw + size};
+    uint32_t f, w;
+    while (rd_tag(c, f, w)) {
+        if (f == 1 && w == 0) {          // field 1, wire=0 (varint): NavigationStatusEnum
+            uint64_t v;
+            if (!rd_varint(c, v)) return false;
+            *status_out = (int)(uint32_t)v;
+            return true;
+        }
+        if (!skip(c, w)) return false;   // unknown field or malformed frame
+    }
+    return false;   // field 1 not present
+}
+
+int hud_nav16_format_guidance(const AaGuidance *g, char *buf, int cap)
+{
+    if (!g || !buf || cap <= 0) return 0;
+    int o = snprintf(buf, cap, "nav16 STATE: maneuver=%u(%s) glyph=%u road=\"%s\" steps=%d lanes=%d",
+                          g->maneuver_type, hud_nav16_maneuver_name(g->maneuver_type),
+                          hud_nav16_glyph(g), g->road, g->n_steps, g->n_lanes);
+    for (int i = 0; i < g->n_lanes && o < cap; ++i)
+        o += snprintf(buf + o, cap - o, " [L%d pres=0x%03x hi=0x%03x]",
+                           i, g->lanes[i].present_mask, g->lanes[i].highlight_mask);
+    return o;
+}
+
+int hud_nav16_format_position(const AaPosition *p, char *buf, int cap)
+{
+    if (!p || !buf || cap <= 0) return 0;
+    return snprintf(buf, cap,
+        "nav16 POS: step=%dm \"%s\" u%u | dest=%dm \"%s\" u%u eta=\"%s\"",
+        p->step_meters, p->step_display, p->step_units,
+        p->dest_meters, p->dest_display, p->dest_units, p->eta);
+}

--- a/mazda/patches/blmjciaapa/hud/hud_nav16.h
+++ b/mazda/patches/blmjciaapa/hud/hud_nav16.h
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// hud_nav16 — Android Auto GAL 1.6 navigation decoder + Mazda HUD glyph/lane map.
+// Handles NavigationState (msgId 0x8006) and NavigationCurrentPosition (0x8007).
+//
+// This is the single place that understands the Android-Auto 1.6 nav protocol:
+// the aap_service shim relays raw frames over the IPC socket and blmjciaapa
+// decodes + maps them here. Pure protobuf walk + constant lookup tables; no I/O,
+// no logging. The Mazda glyph IDs come from MazdaIcon (hud_nav.h) — one enum,
+// shared with the 1.5 path.
+
+#ifndef LIBPATCH_BLMJCIAAPA_HUD_HUD_NAV16_H
+#define LIBPATCH_BLMJCIAAPA_HUD_HUD_NAV16_H
+
+#include <stdint.h>
+
+enum { HUD_NAV16_MAX_LANES = 8 };
+
+// One physical lane: the arrows it shows (Shape 0..9) as bitmasks, plus which
+// are highlighted (recommended). bit s set iff a LaneDirection with shape==s.
+struct AaLane {
+    uint16_t present_mask;
+    uint16_t highlight_mask;
+};
+
+// Encode decoded lanes to the 8-slot HUD lane array, LEFT TO RIGHT. Only
+// marked-vs-unmarked is encoded for a present lane (recommended = highlight_mask
+// != 0); 1 (unmarked) and 22 (marked) are valid on both HUD variants (byte
+// ranges 0-32 and 0-62). The exact per-shape glyph code is TBD on-car.
+//
+// `hidden` (the "no lane in this slot" code) DIFFERS by transport:
+//   - direct VBS_NAVI_SetRecommLaneReq (vbs path): 0xFF hides a slot — confirmed
+//     against the OEM setter + lane_test (AA_NAV16_LANE_HIDDEN).
+//   - GuidanceChangedForHUD signal (svcnavi path): svcjcinavi's handler validates
+//     each lane arg to 0..0x46, so 0xFF is out of range there — pass 0.
+enum {
+    AA_NAV16_LANE_HIDDEN   = 0xFF,   // vbs / SetRecommLaneReq per-slot hide
+    AA_NAV16_LANE_UNMARKED = 1,
+    AA_NAV16_LANE_MARKED   = 22,
+};
+
+inline void aa_nav16_lane_bytes(const AaLane *lanes, uint8_t n,
+                                uint8_t out[8], uint8_t hidden)
+{
+    for (int i = 0; i < 8; ++i) {
+        out[i] = (lanes && i < (int)n)
+                     ? (uint8_t)(lanes[i].highlight_mask ? AA_NAV16_LANE_MARKED
+                                                         : AA_NAV16_LANE_UNMARKED)
+                     : hidden;
+    }
+}
+
+// Decoded NavigationState (the active/first step — the next maneuver).
+struct AaGuidance {
+    bool     have_maneuver;
+    uint32_t maneuver_type;            // NavigationManeuver.NavigationType, 0..42
+    int32_t  roundabout_exit_number;   // field 2 — meaningful for ROUNDABOUT_*
+    int32_t  roundabout_exit_angle;    // field 3 — degrees; selects the roundabout glyph
+    char     road[64];                 // NavigationRoad.name (UTF-8)
+    int      n_steps;                  // total steps present (diagnostic)
+    int      n_lanes;                  // lanes on step[0] (0..8)
+    AaLane   lanes[HUD_NAV16_MAX_LANES];
+};
+
+// Decoded NavigationCurrentPosition.
+struct AaPosition {
+    bool     have_step;                // distance to the next maneuver
+    int32_t  step_meters;
+    char     step_display[16];         // e.g. "350" / "1,3"
+    uint32_t step_units;               // NavigationDistance.DistanceUnits 0..7
+    bool     have_dest;
+    int32_t  dest_meters;
+    char     dest_display[16];
+    uint32_t dest_units;
+    char     eta[16];                  // estimated_time_at_arrival, e.g. "21:54"
+};
+
+// Decode the protobuf BODY (AFTER the 2-byte big-endian msgId). *out is zeroed
+// first; returns true on a clean walk (partial/unknown fields tolerated). Fully
+// bounds-checked — safe on truncated/malformed input (runs in a reset_board PID).
+bool hud_nav16_decode_navstate(const uint8_t *proto, int len, AaGuidance *out);
+bool hud_nav16_decode_position (const uint8_t *proto, int len, AaPosition *out);
+
+// Dispatch on a FULL frame (leading 2-byte big-endian msgId): 0x8006 -> *g,
+// 0x8007 -> *p. Returns the msgId (0 if too short). Pass NULL for the unwanted one.
+uint32_t hud_nav16_on_frame(const uint8_t *raw, int size, AaGuidance *g, AaPosition *p);
+
+// The maneuver-glyph map: decoded guidance -> Mazda HUD glyph (MazdaIcon, and
+// 37..60 for roundabouts by exit angle). The single source of truth for the
+// AA -> HUD maneuver pairing.
+uint8_t hud_nav16_glyph(const AaGuidance *g);
+
+// AA NavigationDistance.DistanceUnits (0..7) -> Mazda HUD unit (1=m,2=mi,3=km,
+// 4=yd,5=ft; 0=none). The 1.6 unit map (distinct from the 1.5 NAVDistanceMessage
+// map_distance_unit in hud_nav.h — different source enum).
+uint8_t aa_to_mazda_unit(uint32_t units);
+
+// Parse an AA display value ("350","1,3","1.3") to the HUD's value*10 form
+// (one decimal): "350"->3500, "1,3"->13. 0 on garbage; overflow-capped.
+int32_t parse_dist_x10(const char *s);
+
+// Pure formatters (snprintf into caller buffer; no I/O) for one-line logging.
+int hud_nav16_format_guidance(const AaGuidance *g, char *buf, int cap);
+int hud_nav16_format_position(const AaPosition *p, char *buf, int cap);
+
+// Name tables for logging (NULL-safe bounds): type 0..42 / shape 0..9.
+const char *hud_nav16_maneuver_name(uint32_t type);
+const char *hud_nav16_shape_name(int shape);
+
+// Read NavigationStatus (0x8003) field 1 (status enum varint) from a FULL frame
+// (leading 2-byte big-endian msgId). Returns true and sets *status_out if found.
+// Fully bounds-checked (same Pb/rd_tag/rd_varint/skip reader as the other decoders).
+// *status_out is set to -1 (sentinel) on entry; unchanged if the field is absent or
+// the frame is malformed. Safe on any phone-originated input.
+bool hud_nav16_read_status(const uint8_t *raw, int size, int *status_out);
+
+#endif  // LIBPATCH_BLMJCIAAPA_HUD_HUD_NAV16_H

--- a/mazda/patches/blmjciaapa/hud/nav16_rx.cpp
+++ b/mazda/patches/blmjciaapa/hud/nav16_rx.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// GAL 1.6 nav receiver — the jciAAPA side of the cross-process HUD path.
+//
+// aap_service (a separate process) swallows the Android Auto 1.6 navigation
+// frames and relays them RAW (an AaNav16Hdr + the original frame bytes) over an
+// abstract AF_UNIX datagram socket. This thread binds that socket, validates the
+// header, and hands the raw frame to hud_feed_nav16_raw(), which decodes it and
+// renders it through the existing HUD transport. So the 1.6 protocol is parsed
+// in exactly one place (hud_nav16, here in blmjciaapa), reusing the same
+// renderer (glyph map, street fold, lanes) as the 1.5 callback path.
+//
+// Lifecycle is bracketed by aap_create/destroy_session via hud.cpp, and only
+// armed when use_protocol_v1_6 is set. Fail-safe: any socket error just leaves
+// the receiver inactive — the seen-latch (hud_nav16_rx_seen) then stays false,
+// our_nav_cb keeps serving the legacy 1.5 callbacks, and the HUD falls back to
+// stock 1.5 behaviour instead of going dark.
+
+#define LOG_TAG "NAV16RX"
+#include "../log.h"
+#include "hud.h"
+#include "common/aa_nav16_msg.h"
+
+#include <atomic>
+#include <cstring>
+#include <pthread.h>
+#include <poll.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+namespace {
+
+std::atomic<bool> g_stop{false};
+std::atomic<bool> g_seen{false};      // a validated 1.6 frame arrived this session
+pthread_t         g_thread    = 0;
+bool              g_thread_up = false;
+int               g_fd        = -1;
+int               g_stop_fd   = -1;   // eventfd: poll()ed by rx_main, written by stop()
+
+int open_rx_socket()
+{
+    int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        LOGE("nav16_rx: socket() failed: %s", strerror(errno));
+        return -1;
+    }
+    struct sockaddr_un addr;
+    socklen_t addrlen;
+    aa_nav16_fill_addr(addr, addrlen);
+
+    if (bind(fd, reinterpret_cast<struct sockaddr *>(&addr), addrlen) != 0) {
+        LOGE("nav16_rx: bind(@%s) failed: %s — receiver inactive",
+             AA_NAV16_SOCKET_NAME, strerror(errno));
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+void *rx_main(void *)
+{
+    g_fd = open_rx_socket();
+    if (g_fd < 0) {
+        return nullptr;
+    }
+    LOGD("nav16_rx: listening on abstract socket @%s", AA_NAV16_SOCKET_NAME);
+
+    while (!g_stop.load(std::memory_order_relaxed)) {
+        // Block until a datagram or the stop eventfd fires — zero idle wakeups
+        // on this CPU-starved box, and stop() interrupts instantly. If the
+        // eventfd couldn't be created (g_stop_fd == -1: poll ignores negative
+        // fds), fall back to a 200 ms timeout so the g_stop check still runs.
+        struct pollfd pfd[2];
+        pfd[0].fd = g_fd;      pfd[0].events = POLLIN; pfd[0].revents = 0;
+        pfd[1].fd = g_stop_fd; pfd[1].events = POLLIN; pfd[1].revents = 0;
+        int r = poll(pfd, 2, (g_stop_fd >= 0) ? -1 : 200);
+        if (r <= 0) continue;                 // timeout or EINTR
+        if (pfd[1].revents & POLLIN) break;   // hud_nav16_rx_stop() signaled
+        if (!(pfd[0].revents & POLLIN)) continue;
+
+        // The datagram is an AaNav16Hdr followed by `len` raw AA frame bytes.
+        // The abstract socket is world-writable, so validate the header before
+        // handing the payload to the decoder.
+        char buf[sizeof(AaNav16Hdr) + AA_NAV16_MAX_FRAME];
+        ssize_t n = recv(g_fd, buf, sizeof(buf), 0);
+        if (n < (ssize_t)sizeof(AaNav16Hdr)) continue;
+        AaNav16Hdr hdr;
+        std::memcpy(&hdr, buf, sizeof(hdr));
+        if (hdr.magic != (uint32_t)AA_NAV16_MAGIC || hdr.version != AA_NAV16_VERSION) {
+            LOGW("nav16_rx: bad magic/version (0x%x v%u) — dropping",
+                 (unsigned)hdr.magic, (unsigned)hdr.version);
+            continue;
+        }
+        int len = (int)hdr.len;
+        if (len < 2 || len > AA_NAV16_MAX_FRAME ||
+            (ssize_t)(sizeof(AaNav16Hdr) + (size_t)len) > n) {
+            LOGW("nav16_rx: bad len %d (n=%ld) — dropping", len, (long)n);
+            continue;
+        }
+        // Latch BEFORE feeding: a validated frame is the proof the whole 1.6
+        // chain took (aap_service shim preloaded, byte-verify passed, phone
+        // accepted the advertisement) — our_nav_cb drops legacy 1.5 callbacks
+        // from here on. exchange() returns the previous value, so the DEBUG
+        // line fires exactly once per session (on the false->true transition).
+        if (!g_seen.exchange(true, std::memory_order_release)) {
+            LOGD("nav16_rx: first 1.6 frame received — 1.5 callback path now suppressed");
+        }
+        hud_feed_nav16_raw(reinterpret_cast<const uint8_t *>(buf) + sizeof(AaNav16Hdr),
+                           len);
+    }
+
+    close(g_fd);
+    g_fd = -1;
+    LOGD("nav16_rx: thread exiting");
+    return nullptr;
+}
+
+} // namespace
+
+void hud_nav16_rx_start(void)
+{
+    if (g_thread_up) {
+        return;
+    }
+    // The previous session may have ended without a clean INACTIVE/STOP
+    // (cable pull) — reset the decoder state here, before the rx thread
+    // exists, so it can't suppress the new session's first frame. The seen
+    // latch resets with it: every session must re-prove it speaks 1.6, so a
+    // phone that drops back to 1.5 gets the legacy path again.
+    hud_feed_nav16_reset();
+    g_seen.store(false, std::memory_order_release);
+    g_stop.store(false, std::memory_order_release);
+    g_stop_fd = eventfd(0, EFD_CLOEXEC);
+    if (g_stop_fd < 0) {
+        LOGW("hud_nav16_rx_start: eventfd failed (%s) — rx falls back to 200 ms poll",
+             strerror(errno));
+    }
+    if (pthread_create(&g_thread, nullptr, rx_main, nullptr) != 0) {
+        LOGC("hud_nav16_rx_start: pthread_create failed — no 1.6 HUD this session");
+        if (g_stop_fd >= 0) {
+            close(g_stop_fd);
+            g_stop_fd = -1;
+        }
+        return;
+    }
+    g_thread_up = true;
+    LOGD("hud_nav16_rx_start: receiver thread spawned");
+}
+
+bool hud_nav16_rx_seen(void)
+{
+    return g_seen.load(std::memory_order_acquire);
+}
+
+void hud_nav16_rx_stop(void)
+{
+    if (!g_thread_up) {
+        return;
+    }
+    g_stop.store(true, std::memory_order_release);
+    if (g_stop_fd >= 0) {
+        // Wake the blocking poll(). An 8-byte eventfd write is atomic and the
+        // counter (0 or 1 here) can't saturate, so only EINTR needs handling.
+        uint64_t one = 1;
+        while (write(g_stop_fd, &one, sizeof(one)) < 0 && errno == EINTR) {}
+    }
+    pthread_join(g_thread, nullptr);
+    if (g_stop_fd >= 0) {
+        close(g_stop_fd);                     // after join: rx_main can't touch it now
+        g_stop_fd = -1;
+    }
+    g_thread_up = false;
+    g_thread    = 0;
+    LOGD("hud_nav16_rx_stop: receiver thread stopped");
+}

--- a/mazda/patches/blmjciaapa/hud/svcnavi_tx.cpp
+++ b/mazda/patches/blmjciaapa/hud/svcnavi_tx.cpp
@@ -29,6 +29,7 @@
 #include "hud_nav.h"
 #include "../oem/libdbus.h"
 #include "../../common/oem/vbs_navi_hud.h"   // kAapSpeedSentinel (shared with svcjcinavi)
+#include "common/config.h"                   // libpatch_config::hud_lanes()
 
 #include <condition_variable>
 #include <cstdlib>
@@ -74,6 +75,13 @@ struct NaviSnapshot {
     int32_t  distance_dec;   // value * 10
     uint8_t  distance_unit;  // mapped to Mazda enum
     int32_t  time_until;
+    // GAL 1.6 path: the glyph is precomputed (Mazda code) rather than derived
+    // from turn_event/side/angle, and lanes are carried through. The 1.5 path
+    // leaves use_precomp false (zeroed), so it keeps using compute_turn_icon().
+    bool        use_precomp;
+    uint32_t    precomp_icon;
+    uint8_t     n_lanes;
+    AaLane lanes[HUD_NAV16_MAX_LANES];
 };
 
 NaviSnapshot            g_snapshot = {};
@@ -101,7 +109,8 @@ bool append_i32(DBusMessageIter *iter, int32_t value)
 // way the NNG engine emits it (libjcidbus's signal_send would reject
 // a signal we don't serve).
 void emit_guidance(uint32_t dir_icon, int32_t maneuver_dist,
-                   int32_t dist_unit, const char *street)
+                   int32_t dist_unit, const char *street,
+                   const AaLane *lanes, uint8_t n_lanes)
 {
     void *msg = dbus_message_new_signal(kSignalPath, kSignalIface, kSignalMember);
     if (msg == nullptr) {
@@ -120,8 +129,15 @@ void emit_guidance(uint32_t dir_icon, int32_t maneuver_dist,
     ok = ok && (dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &s) != 0);
     ok = ok && append_i32(&it, kAapSpeedSentinel); // speedLimit
     ok = ok && append_i32(&it, 0);                 // speedUnit
+    // lane0..7. Each is the HUD lane-glyph byte svcjcinavi forwards to
+    // SetRecommLaneReq: marked(22)/unmarked(1), 0 = no lane. We pass 0 (not
+    // 0xFF) for empty slots because svcjcinavi's handler validates each lane arg
+    // to 0..0x46 and would reject 0xFF. The 1.5 path passes lanes=null/n=0 -> all
+    // zero, unchanged. (Exact per-shape glyph code TBD on-car.)
+    uint8_t lb[8];
+    aa_nav16_lane_bytes(lanes, n_lanes, lb, /*hidden=*/0);
     for (int i = 0; i < 8 && ok; ++i) {
-        ok = append_i32(&it, 0);                   // lane0..7
+        ok = append_i32(&it, static_cast<int32_t>(lb[i]));
     }
     if (!ok) {
         LOGE("svcnavi sender: marshalling GuidanceChangedForHUD failed (OOM)");
@@ -152,12 +168,20 @@ void emit_guidance(uint32_t dir_icon, int32_t maneuver_dist,
 // frame was dropped.
 void send_one(const NaviSnapshot &cur)
 {
-    uint32_t icon = compute_turn_icon(cur.turn_event, cur.turn_side, cur.turn_angle);
+    uint32_t icon = cur.use_precomp
+                        ? cur.precomp_icon
+                        : compute_turn_icon(cur.turn_event, cur.turn_side, cur.turn_angle);
 
+    // Lane forwarding shares the hud_lanes kill-switch with the vbs
+    // transport; off -> all-zero lane slots ("no lane"), byte-identical
+    // to the 1.5 path.
+    const bool send_lanes = libpatch_config::hud_lanes() && cur.use_precomp;
     emit_guidance(icon,
                   cur.distance_dec,
                   cur.distance_unit,
-                  cur.road_name);
+                  cur.road_name,
+                  send_lanes ? cur.lanes : nullptr,
+                  send_lanes ? cur.n_lanes : 0);
 }
 
 // Bring up the service-bus connection on the sender thread. Returns
@@ -211,8 +235,8 @@ void sender_teardown()
 
     // Emit a zeroed guidance frame so svcjcinavi blanks the HUD
     // instead of holding our last maneuver. dirIcon 0, dist 0, empty
-    // street; sentinel speed still marks it as ours.
-    emit_guidance(0, 0, 0, "");
+    // street, no lanes; sentinel speed still marks it as ours.
+    emit_guidance(0, 0, 0, "", nullptr, 0);
     LOGD("svcnavi sender: sent blanking GuidanceChangedForHUD");
 
     // Private connections must be closed before the final unref.
@@ -364,6 +388,7 @@ void svcnavi_tx_next_turn(const char *road_name,
     g_snapshot.turn_event  = turn_event;
     g_snapshot.turn_angle  = turn_angle;
     g_snapshot.turn_number = turn_number;
+    g_snapshot.use_precomp = false;   // 1.5 path: derive the glyph from turn_event
     seqlock_end();
 }
 
@@ -381,5 +406,39 @@ void svcnavi_tx_distance(int32_t  /*distance_meters*/,
     g_snapshot.distance_dec  = display_distance / 100;  // *1000 -> *10
     g_snapshot.distance_unit = map_distance_unit(display_distance_unit);
     g_snapshot.time_until    = time_until_seconds;
+    seqlock_end();
+}
+
+void svcnavi_tx_v16(uint32_t glyph, const char *road,
+                    int32_t dist_dec, uint8_t dist_unit,
+                    const AaLane *lanes, uint8_t n_lanes)
+{
+    if (!g_active.load(std::memory_order_relaxed)) {
+        note_inactive_drop("v16 guidance");
+        return;
+    }
+
+    uint8_t nl = (n_lanes > HUD_NAV16_MAX_LANES) ? HUD_NAV16_MAX_LANES : n_lanes;
+
+    seqlock_begin();
+    if (road) {
+        std::strncpy(g_snapshot.road_name, road, sizeof(g_snapshot.road_name) - 1);
+        g_snapshot.road_name[sizeof(g_snapshot.road_name) - 1] = '\0';
+    } else {
+        g_snapshot.road_name[0] = '\0';
+    }
+    g_snapshot.use_precomp   = true;
+    g_snapshot.precomp_icon  = glyph;
+    g_snapshot.distance_dec  = dist_dec;
+    g_snapshot.distance_unit = dist_unit;
+    g_snapshot.n_lanes       = nl;
+    for (uint8_t i = 0; i < HUD_NAV16_MAX_LANES; ++i) {
+        if (lanes && i < nl) {
+            g_snapshot.lanes[i] = lanes[i];
+        } else {
+            g_snapshot.lanes[i].present_mask   = 0;
+            g_snapshot.lanes[i].highlight_mask = 0;
+        }
+    }
     seqlock_end();
 }

--- a/mazda/patches/blmjciaapa/hud/svcnavi_tx.h
+++ b/mazda/patches/blmjciaapa/hud/svcnavi_tx.h
@@ -47,6 +47,7 @@
 #define LIBPATCH_BLMJCIAAPA_HUD_SVCNAVI_TX_H
 
 #include <stdint.h>
+#include "hud_nav16.h"   // AaLane, aa_nav16_lane_bytes, AA_NAV16_LANE_*
 
 // HUD output lifecycle. svcnavi_tx_start opens the OEM service-bus
 // connection (libjcidbus, exit-on-disconnect disabled) on a
@@ -81,5 +82,18 @@ void svcnavi_tx_distance(int32_t  distance_meters,
                          int32_t  time_until_seconds,
                          int32_t  display_distance,
                          uint32_t display_distance_unit);
+
+// Android Auto GAL 1.6 path (fed from the aap_service shim via blmjciaapa's
+// nav16 receiver). The maneuver glyph is ALREADY the Mazda HUD code, distance
+// is already value*10 in the Mazda unit, and lanes are carried through to
+// lane0..7 of GuidanceChangedForHUD. One call sets the whole frame.
+//   glyph     - Mazda HUD maneuver code (MazdaIcon; 0=blank)
+//   road      - street name (already latin-folded by the caller)
+//   dist_dec  - display distance * 10
+//   dist_unit - Mazda HUD unit (1=m,2=mi,3=km,4=yd,5=ft; 0=none)
+//   lanes/n   - up to 8 decoded lanes (may be null / 0)
+void svcnavi_tx_v16(uint32_t glyph, const char *road,
+                    int32_t dist_dec, uint8_t dist_unit,
+                    const AaLane *lanes, uint8_t n_lanes);
 
 #endif // LIBPATCH_BLMJCIAAPA_HUD_SVCNAVI_TX_H

--- a/mazda/patches/blmjciaapa/hud/vbs_tx.cpp
+++ b/mazda/patches/blmjciaapa/hud/vbs_tx.cpp
@@ -41,6 +41,7 @@
 #include "vbs_tx.h"
 #include "hud_nav.h"
 #include "../oem/libjcivbsnaviclient.h"
+#include "common/config.h"   // libpatch_config::hud_lanes()
 
 #include <chrono>
 #include <condition_variable>
@@ -85,6 +86,12 @@ struct NaviSnapshot {
     int32_t  distance_dec;       // value * 10 (one decimal place)
     uint8_t  distance_unit;      // ALREADY mapped to Mazda enum
     int32_t  time_until;         // seconds — ETA to next maneuver
+    // GAL 1.6 path: glyph precomputed (Mazda code) instead of derived from
+    // turn_event/side/angle. The 1.5 path leaves use_precomp false (zeroed).
+    bool        use_precomp;
+    uint32_t    precomp_icon;
+    uint8_t     n_lanes;
+    AaLane lanes[HUD_NAV16_MAX_LANES];
 };
 
 NaviSnapshot           g_snapshot   = {};
@@ -161,10 +168,19 @@ void send_one(const NaviSnapshot &cur,
     // i.e. when the maneuver icon changes OR the street name changes —
     // not on distance/speed ticks. Mirror that: a new road name or a
     // new resolved turn-icon both start a new instance.
+    // Resolve the glyph: precomputed (1.6 path) or derived from the turn fields
+    // (1.5 path). Compute both cur and prev so the change-detection below sees
+    // glyph changes on either path.
+    uint32_t cur_icon  = cur.use_precomp
+                             ? cur.precomp_icon
+                             : compute_turn_icon(cur.turn_event, cur.turn_side, cur.turn_angle);
+    uint32_t prev_icon = prev.use_precomp
+                             ? prev.precomp_icon
+                             : compute_turn_icon(prev.turn_event, prev.turn_side, prev.turn_angle);
+
     bool event_changed = (std::strncmp(cur.road_name, prev.road_name,
                                        sizeof(cur.road_name)) != 0) ||
-                         (compute_turn_icon(cur.turn_event, cur.turn_side, cur.turn_angle) !=
-                          compute_turn_icon(prev.turn_event, prev.turn_side, prev.turn_angle));
+                         (cur_icon != prev_icon);
     bool distance_changed = event_changed ||
                             cur.distance_dec  != prev.distance_dec  ||
                             cur.distance_unit != prev.distance_unit ||
@@ -173,7 +189,23 @@ void send_one(const NaviSnapshot &cur,
                             cur.turn_side     != prev.turn_side     ||
                             cur.turn_event    != prev.turn_event;
 
-    if (!event_changed && !distance_changed) {
+    // Lanes ride a SEPARATE OEM method (SetRecommLaneReq, see below). Encode
+    // both frames' lanes to the HUD byte form and send only when they differ
+    // (the 1.5 path has no lanes -> both encode to all-0xFF -> never sent).
+    // Direct SetRecommLaneReq path: 0xFF hides an empty slot.
+    // Gated by hud_lanes: runtime kill-switch for the lane path, so lane sends
+    // can be turned off in the field. See libjcivbsnaviclient.h for the OEM
+    // lane setter's ABI.
+    const bool lanes_enabled = libpatch_config::hud_lanes();
+    uint8_t cur_lanes[8], prev_lanes[8];
+    aa_nav16_lane_bytes(cur.use_precomp  ? cur.lanes  : nullptr,
+                        cur.use_precomp  ? cur.n_lanes  : 0, cur_lanes,  AA_NAV16_LANE_HIDDEN);
+    aa_nav16_lane_bytes(prev.use_precomp ? prev.lanes : nullptr,
+                        prev.use_precomp ? prev.n_lanes : 0, prev_lanes, AA_NAV16_LANE_HIDDEN);
+    bool lanes_changed = lanes_enabled &&
+                         std::memcmp(cur_lanes, prev_lanes, sizeof(cur_lanes)) != 0;
+
+    if (!event_changed && !distance_changed && !lanes_changed) {
         LOGV("hud_send: snapshot unchanged vs previous — no HUD frame sent");
         return;
     }
@@ -188,39 +220,58 @@ void send_one(const NaviSnapshot &cur,
     VbsNaviHudMsg2    msg2 = {};
     std::string       road;
 
-    if (event_changed) {
-        // Per reference: bump 1..7 cyclically. The HUD treats a
-        // sync_bit change as a hint to refresh the street-name page
-        // even if the underlying string is identical.
+    // A lane array carries no sync of its own — the HUD pairs it with the
+    // maneuver + street frames of the SAME sync generation. So a lane change
+    // starts a new generation just like a maneuver change, and whenever lanes
+    // are sent we re-send the maneuver + street frames carrying that same bumped
+    // sync (this is what the OEM / lane_test do: all three per generation). A
+    // distance-only tick stays in the current generation (no bump, no lanes).
+    bool send_msg2  = event_changed || lanes_changed;   // street strip (carries the sync)
+    bool send_disp  = distance_changed || send_msg2;     // maneuver/distance frame
+    // Re-send lanes with a new sync generation only when there is a lane to
+    // show — an all-hidden array has nothing to pair with the generation, and
+    // shown->hidden transitions are already covered by lanes_changed.
+    bool cur_lanes_visible = false;
+    for (size_t i = 0; i < sizeof(cur_lanes); ++i) {
+        if (cur_lanes[i] != AA_NAV16_LANE_HIDDEN) { cur_lanes_visible = true; break; }
+    }
+    bool send_lanes = lanes_changed ||
+                      (lanes_enabled && cur.use_precomp && send_msg2 && cur_lanes_visible);
+
+    if (send_msg2) {
+        // Bump 1..7 cyclically — the HUD treats a new sync_bit as the start of a
+        // new maneuver/street/lane generation.
         sync_bit = static_cast<uint8_t>((sync_bit % 7) + 1);
         road = cur.road_name;
         msg2.guidancePointName = road.c_str();
         msg2.syncBit           = sync_bit;
     }
 
-    if (distance_changed) {
-        uint32_t icon = compute_turn_icon(cur.turn_event, cur.turn_side, cur.turn_angle);
+    if (send_disp) {
+        uint32_t icon = cur_icon;
 
 #ifdef DEBUG
         // Debug aid: when our mapping produced no glyph for this
         // (turn_event, turn_side) pair, hijack the street-name strip
         // to show the raw codes so an observer on the HUD can record
-        // them and extend the table later. Stripped in release.
+        // them and extend the table later. Stripped in release. Skipped
+        // on the 1.6 path (use_precomp): glyph 0 there is a real "blank",
+        // and turn_event/side carry no meaning to display.
         char dbg_label[33];
-        if (icon == 0) {
+        if (icon == 0 && !cur.use_precomp) {
             snprintf(dbg_label, sizeof(dbg_label),
                      "EV=%u S=%u A=%d",
                           static_cast<unsigned>(cur.turn_event),
                           static_cast<unsigned>(cur.turn_side),
                           static_cast<int>(cur.turn_angle));
-            if (!event_changed) {
+            if (!send_msg2) {
                 sync_bit = static_cast<uint8_t>((sync_bit % 7) + 1);
             }
             road = dbg_label;
             msg2.guidancePointName = road.c_str();
             msg2.syncBit           = sync_bit;
             icon = MazdaIcon::HUD_EMPTY;
-            event_changed = true;   // force Msg2 send below
+            send_msg2 = true;   // force Msg2 send below
         }
 #endif
 
@@ -230,9 +281,12 @@ void send_one(const NaviSnapshot &cur,
         disp.displaySpeedLimit = 0;     // speed limit — unused here
         disp.displaySpeedUnit  = 0;     // speed units — unused here
         disp.text_ID3          = sync_bit;
+        // Lanes are NOT part of this uqyqyy frame — they go on their own OEM
+        // method, VBS_NAVI_SetRecommLaneReq ((ay)), sent below in the same sync
+        // generation.
     }
 
-    if (distance_changed) {
+    if (send_disp) {
         LOGV("hud_send: SetHUDDisplayMsgReq icon=%u dist=%u unit=%u sync=%u",
              static_cast<unsigned>(disp.nextManeuverInfo),
              static_cast<unsigned>(disp.distanceValue),
@@ -243,12 +297,30 @@ void send_one(const NaviSnapshot &cur,
             LOGE("hud_send: SetHUDDisplayMsgReq failed rc=%d", rc);
         }
     }
-    if (event_changed) {
+    if (send_msg2) {
         LOGV("hud_send: SetHUD_Display_Msg2 road=\"%s\" sync=%u",
              road.c_str(), static_cast<unsigned>(msg2.syncBit));
         int rc = VBS_NAVI_TMC_SetHUD_Display_Msg2(g_conn, &msg2, nullptr, nullptr, nullptr);
         if (rc != 0) {
             LOGE("hud_send: SetHUD_Display_Msg2 failed rc=%d", rc);
+        }
+    }
+    if (send_lanes) {
+        // Same sync generation as the disp/msg2 just sent (send_msg2 is forced
+        // true whenever lanes go out, so sync was bumped above). The HUD ties the
+        // lane array to that generation. 8 bytes, 0xFF hides a slot. The OEM
+        // setter dereferences both middle args (see libjcivbsnaviclient.h), so
+        // it gets pointers to the data pointer and the count.
+        const uint8_t *lane_data  = cur_lanes;
+        const uint32_t lane_count = sizeof(cur_lanes);
+        int rc = VBS_NAVI_SetRecommLaneReq(g_conn, &lane_data, &lane_count,
+                                           nullptr, nullptr);
+        LOGV("hud_send: SetRecommLaneReq sync=%u [%u %u %u %u %u %u %u %u] rc=%d",
+             static_cast<unsigned>(sync_bit),
+             cur_lanes[0], cur_lanes[1], cur_lanes[2], cur_lanes[3],
+             cur_lanes[4], cur_lanes[5], cur_lanes[6], cur_lanes[7], rc);
+        if (rc != 0) {
+            LOGE("hud_send: SetRecommLaneReq failed rc=%d", rc);
         }
     }
 }
@@ -331,7 +403,17 @@ void sender_teardown()
         } else {
             LOGD("hud sender: sent HUD clear frame");
         }
-        // The clear frame is queued on the libjcidbus worker; give it
+        // Hide any lanes a 1.6 session left on the HUD (all slots hidden).
+        // Only when lane sends are enabled — none were shown otherwise.
+        if (libpatch_config::hud_lanes()) {
+            uint8_t clear_lanes[8];
+            std::memset(clear_lanes, AA_NAV16_LANE_HIDDEN, sizeof(clear_lanes));
+            const uint8_t *lane_data  = clear_lanes;
+            const uint32_t lane_count = sizeof(clear_lanes);
+            VBS_NAVI_SetRecommLaneReq(g_conn, &lane_data, &lane_count,
+                                      nullptr, nullptr);
+        }
+        // The frames are queued on the libjcidbus worker; give them
         // a brief moment to flush before we stop the worker below.
         usleep(50 * 1000);
     }
@@ -531,6 +613,7 @@ void vbs_tx_next_turn(const char *road_name,
     g_snapshot.turn_event  = turn_event;
     g_snapshot.turn_angle  = turn_angle;
     g_snapshot.turn_number = turn_number;
+    g_snapshot.use_precomp = false;   // 1.5 path: derive the glyph from turn_event
     seqlock_end();
 }
 
@@ -549,5 +632,39 @@ void vbs_tx_distance(int32_t  /*distance_meters*/,
     g_snapshot.distance_dec  = display_distance / 100;
     g_snapshot.distance_unit = map_distance_unit(display_distance_unit);
     g_snapshot.time_until    = time_until_seconds;
+    seqlock_end();
+}
+
+void vbs_tx_v16(uint32_t glyph, const char *road,
+                int32_t dist_dec, uint8_t dist_unit,
+                const AaLane *lanes, uint8_t n_lanes)
+{
+    if (!g_active.load(std::memory_order_relaxed)) {
+        note_inactive_drop("v16 guidance");
+        return;
+    }
+
+    uint8_t nl = (n_lanes > HUD_NAV16_MAX_LANES) ? HUD_NAV16_MAX_LANES : n_lanes;
+
+    seqlock_begin();
+    if (road) {
+        std::strncpy(g_snapshot.road_name, road, sizeof(g_snapshot.road_name) - 1);
+        g_snapshot.road_name[sizeof(g_snapshot.road_name) - 1] = '\0';
+    } else {
+        g_snapshot.road_name[0] = '\0';
+    }
+    g_snapshot.use_precomp   = true;
+    g_snapshot.precomp_icon  = glyph;
+    g_snapshot.distance_dec  = dist_dec;
+    g_snapshot.distance_unit = dist_unit;
+    g_snapshot.n_lanes       = nl;
+    for (uint8_t i = 0; i < HUD_NAV16_MAX_LANES; ++i) {
+        if (lanes && i < nl) {
+            g_snapshot.lanes[i] = lanes[i];
+        } else {
+            g_snapshot.lanes[i].present_mask   = 0;
+            g_snapshot.lanes[i].highlight_mask = 0;
+        }
+    }
     seqlock_end();
 }

--- a/mazda/patches/blmjciaapa/hud/vbs_tx.h
+++ b/mazda/patches/blmjciaapa/hud/vbs_tx.h
@@ -31,6 +31,7 @@
 #define LIBPATCH_BLMJCIAAPA_VBS_TX_H
 
 #include <stdint.h>
+#include "hud_nav16.h"   // AaLane, aa_nav16_lane_bytes, AA_NAV16_LANE_*
 
 // Defined in vbs_tx.cpp. HUD output lifecycle. vbs_tx_start opens
 // the OEM HMI + Service D-Bus connections, spawns a dispatcher
@@ -72,5 +73,14 @@ void vbs_tx_distance(int32_t  distance_meters,
                      int32_t  time_until_seconds,
                      int32_t  display_distance,
                      uint32_t display_distance_unit);
+
+// Android Auto GAL 1.6 path. The maneuver glyph is ALREADY the Mazda HUD code
+// and distance is already value*10 in the Mazda unit. Lanes are carried through
+// so the direct path is lane-ready; see vbs_tx.cpp for the emit-side OEM-ABI
+// note (the basic VBS_NAVI_SetHUDDisplayMsgReq frame has no lane field). One
+// call sets the frame.
+void vbs_tx_v16(uint32_t glyph, const char *road,
+                int32_t dist_dec, uint8_t dist_unit,
+                const AaLane *lanes, uint8_t n_lanes);
 
 #endif // LIBPATCH_BLMJCIAAPA_VBS_TX_H

--- a/mazda/patches/blmjciaapa/oem/libjcivbsnaviclient.cpp
+++ b/mazda/patches/blmjciaapa/oem/libjcivbsnaviclient.cpp
@@ -38,3 +38,7 @@ OEM_THUNK(int, VBS_NAVI_TMC_SetHUD_Display_Msg2,
           (conn, msg2, unused, cb, user), -1)
 OEM_THUNK(int, VBS_NAVI_GetHUDStatus,
           (void *conn, void *cb, void *user), (conn, cb, user), -1)
+OEM_THUNK(int, VBS_NAVI_SetRecommLaneReq,
+          (void *conn, const uint8_t *const *lanes, const uint32_t *count,
+           void *cb, void *user),
+          (conn, lanes, count, cb, user), -1)

--- a/mazda/patches/blmjciaapa/oem/libjcivbsnaviclient.h
+++ b/mazda/patches/blmjciaapa/oem/libjcivbsnaviclient.h
@@ -37,4 +37,14 @@ int VBS_NAVI_TMC_SetHUD_Display_Msg2(void *conn, VbsNaviHudMsg2 *msg2,
                                      void *unused, void *cb, void *user);
 int VBS_NAVI_GetHUDStatus(void *conn, void *cb, void *user);
 
+// Recommended-lane setter, wire signature ((ay)). UNLIKE the sibling setters
+// (which take the wire struct by pointer and read fields at offsets), this
+// one takes POINTERS to the data pointer and to the element count and
+// dereferences both. `*lanes` points at `*count` bytes — the HUD consumes 8,
+// one per lane slot, left→right; 0xFF hides a slot. The bytes are copied while
+// marshalling (the send is queued).
+// (conn, &data, &count, completion_cb, user) -> int (0 = queued OK).
+int VBS_NAVI_SetRecommLaneReq(void *conn, const uint8_t *const *lanes,
+                              const uint32_t *count, void *cb, void *user);
+
 #endif  // LIBPATCH_BLMJCIAAPA_LIBJCIVBSNAVICLIENT_H

--- a/mazda/patches/common/aa_nav16_msg.h
+++ b/mazda/patches/common/aa_nav16_msg.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Cross-process transport for the Android Auto GAL 1.6 HUD path.
+//
+// aap_service and jciAAPA are SEPARATE processes. The aap_service shim catches
+// the 1.6 navigation frames and RELAYS them, unparsed, to the blmjciaapa shim
+// (in jciAAPA), which decodes them, maps them to the Mazda HUD domain, and
+// renders them through the existing HUD transport (glyph + street fold + lanes).
+// So there is exactly ONE place that knows the Android-Auto protocol (blmjciaapa)
+// — aap_service is a dumb relay. The wire therefore carries the RAW AA frame
+// bytes (a small header + the original [2-byte BE msgId][protobuf] payload).
+//
+// Transport: an abstract-namespace AF_UNIX SOCK_DGRAM socket. Both ends build
+// the address via aa_nav16_fill_addr() below — a leading NUL byte followed by
+// AA_NAV16_SOCKET_NAME (Linux abstract sockets — no filesystem node,
+// auto-released on close). The receiver validates magic + version + length
+// before parsing a datagram.
+
+#ifndef LIBPATCH_COMMON_AA_NAV16_MSG_H
+#define LIBPATCH_COMMON_AA_NAV16_MSG_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#define AA_NAV16_SOCKET_NAME "mazda-aa-nav16-hud"
+
+enum {
+    AA_NAV16_MAGIC     = 0x41483136,   // 'AH16'
+    AA_NAV16_VERSION   = 1,
+    AA_NAV16_MAX_FRAME = 1024,         // cap on the relayed AA frame payload
+};
+
+// GAL navigation-channel msgIds — the 2-byte big-endian prefix of every frame.
+// This is the sender/receiver contract: aap_service swallows + relays the whole
+// SWALLOW range below (anything the OEM 1.5 endpoint doesn't handle gets its
+// routeMessage -253 -> {00 FF} -> full AA teardown, the worst failure mode in
+// the system), and blmjciaapa dispatches on the individual ids. Both ends must
+// use THESE names, never re-derived literals.
+enum {
+    AA_NAV16_MSG_CLUSTER_START  = 0x8001,  // InstrumentClusterStart — nothing to render
+    AA_NAV16_MSG_CLUSTER_STOP   = 0x8002,  // InstrumentClusterStop — blank the HUD
+    AA_NAV16_MSG_STATUS         = 0x8003,  // NavigationStatus (lifecycle; also GAL 1.5)
+    AA_NAV16_MSG_NEXT_TURN      = 0x8004,  // NavigationNextTurnEvent (1.5 — OEM handles)
+    AA_NAV16_MSG_NEXT_TURN_DIST = 0x8005,  // NavigationNextTurnDistanceEvent (1.5 — OEM handles)
+    AA_NAV16_MSG_NAV_STATE      = 0x8006,  // NavigationState (1.6: maneuver + road + lanes)
+    AA_NAV16_MSG_POSITION       = 0x8007,  // NavigationCurrentPosition (1.6: distance)
+
+    // The contiguous range hook_routeMessage swallows and relays raw.
+    AA_NAV16_MSG_SWALLOW_FIRST  = AA_NAV16_MSG_CLUSTER_START,
+    AA_NAV16_MSG_SWALLOW_LAST   = AA_NAV16_MSG_POSITION,
+};
+
+// Datagram header, immediately followed by `len` raw AA frame bytes (the full
+// frame including its leading 2-byte big-endian msgId). 8 bytes, gap-free.
+struct AaNav16Hdr {
+    uint32_t magic;      // AA_NAV16_MAGIC
+    uint8_t  version;    // AA_NAV16_VERSION
+    uint8_t  reserved;   // 0
+    uint16_t len;        // number of raw frame bytes that follow (2..AA_NAV16_MAX_FRAME)
+};
+static_assert(sizeof(AaNav16Hdr) == 8, "AaNav16Hdr is the on-wire header — keep it 8 bytes, gap-free");
+
+// Fill the abstract-namespace socket address both processes rendezvous on.
+// Sender and receiver MUST produce byte-identical addresses (a mismatch is
+// silent: bind succeeds, sendto just gets ECONNREFUSED) — so this is the one
+// definition, next to the socket name it encodes.
+static inline void aa_nav16_fill_addr(struct sockaddr_un &addr, socklen_t &addrlen)
+{
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    const size_t namelen = sizeof(AA_NAV16_SOCKET_NAME) - 1;
+    addr.sun_path[0] = '\0';                                  // abstract namespace
+    memcpy(addr.sun_path + 1, AA_NAV16_SOCKET_NAME, namelen);
+    addrlen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + namelen);
+}
+
+#endif  // LIBPATCH_COMMON_AA_NAV16_MSG_H

--- a/mazda/patches/common/config.h
+++ b/mazda/patches/common/config.h
@@ -22,7 +22,15 @@
 //   force_street_name = true|false    rewrite the HUD street strip with the AAP
 //                                     street even where the OEM blanks it (default false)
 //   hud_fold_latin = true|false       fold HUD-unrenderable precomposed Latin
-//                                     street-name letters to their base forms (default true)
+//                                     street-name letters to their base forms (default false)
+//   hud_lanes     = true|false        send AA lane guidance to the HUD; kill-switch for
+//                                     the lane path on both transports (vbs: the OEM
+//                                     VBS_NAVI_SetRecommLaneReq call, svcnavi: the lane
+//                                     fields of GuidanceChangedForHUD) (default true)
+//   use_protocol_v1_6 = true|false    advertise Android Auto GAL 1.6 so the phone sends the
+//                                     1.6 navigation protocol (maneuver / lanes / distance)
+//                                     instead of the 1.5 turn events; read by aap_service
+//                                     (default false = stock 1.5)
 //
 // Booleans are lenient (true/1/yes/on, false/0/no/off). hud_transport
 // also accepts "svcjcinavi" as an alias for "svcnavi".
@@ -202,6 +210,8 @@ struct Settings {
     HudTransport hud_transport     = HUD_TRANSPORT_SVCNAVI;
     bool         force_street_name = false;
     bool         hud_fold_latin    = false;
+    bool         hud_lanes         = true;
+    bool         use_protocol_v1_6 = false;
     bool         loaded            = false;
 };
 
@@ -242,6 +252,10 @@ inline void apply_kv(const char *key, const char *val, void *ud)
         s.force_street_name = parse_bool(val, s.force_street_name);
     } else if (strcasecmp(key, "hud_fold_latin") == 0) {
         s.hud_fold_latin = parse_bool(val, s.hud_fold_latin);
+    } else if (strcasecmp(key, "hud_lanes") == 0) {
+        s.hud_lanes = parse_bool(val, s.hud_lanes);
+    } else if (strcasecmp(key, "use_protocol_v1_6") == 0) {
+        s.use_protocol_v1_6 = parse_bool(val, s.use_protocol_v1_6);
     } else {
         // Common schema: a key this library doesn't act on is not an
         // error, just informational.
@@ -253,13 +267,15 @@ inline void log_effective(const char *prefix)
 {
     const Settings &s = settings();
     LOGD("config: %s touch=%s hud=%s hud_transport=%s force_street_name=%s "
-         "hud_fold_latin=%s",
+         "hud_fold_latin=%s hud_lanes=%s use_protocol_v1_6=%s",
          prefix,
          s.touch ? "true" : "false",
          s.hud   ? "true" : "false",
          transport_name(s.hud_transport),
          s.force_street_name ? "true" : "false",
-         s.hud_fold_latin ? "true" : "false");
+         s.hud_fold_latin ? "true" : "false",
+         s.hud_lanes ? "true" : "false",
+         s.use_protocol_v1_6 ? "true" : "false");
 }
 
 // === Public API ===============================================
@@ -300,6 +316,8 @@ inline bool         hud_enabled()    { return settings().hud; }
 inline HudTransport hud_transport()  { return settings().hud_transport; }
 inline bool         force_street_name() { return settings().force_street_name; }
 inline bool         hud_fold_latin() { return settings().hud_fold_latin; }
+inline bool         hud_lanes()      { return settings().hud_lanes; }
+inline bool         use_protocol_v1_6() { return settings().use_protocol_v1_6; }
 
 } // namespace libpatch_config
 

--- a/mazda/patches/common/preload_guard.h
+++ b/mazda/patches/common/preload_guard.h
@@ -199,4 +199,22 @@ static inline bool preload_is_launcher_process(const char *cmdline)
     return blen == kTlen && memcmp(base, kTarget, kTlen) == 0;
 }
 
+// True iff argv[0] is the aap_service executable. The aap_service shim patches
+// fixed virtual addresses inside aap_service; since LD_PRELOAD is inherited by
+// every process aap_service forks/execs (e.g. gst-plugin-scanner), those
+// addresses are unmapped in the child and patching there would fault. Gate on
+// argv[0] so the shim stays inert in inherited children. Compares the BASENAME
+// of argv[0] to "aap_service" (exact), like preload_is_launcher_process — not a
+// substring match, so a sibling such as /tmp/aap_service_helper can't trip it.
+static inline bool preload_in_aap_service()
+{
+    char cl[256];
+    if (preload_read_cmdline(cl, sizeof cl) <= 0) return false;
+    char *sp = strchr(cl, ' ');
+    if (sp) *sp = '\0';                  // keep argv[0] only
+    const char *base = strrchr(cl, '/');
+    base = base ? base + 1 : cl;         // basename of argv[0]
+    return strcmp(base, "aap_service") == 0;
+}
+
 #endif  // LIBPATCH_COMMON_PRELOAD_GUARD_H

--- a/resources/libpatch.conf
+++ b/resources/libpatch.conf
@@ -33,6 +33,12 @@ hud = true
 # Default: svcnavi
 hud_transport = svcnavi
 
+# Send Android Auto lane guidance to the HUD. Set false to stop sending lane
+# data. Lanes only appear with use_protocol_v1_6 = true (below), so this has
+# no effect on a stock 1.5 setup.
+# Default: true
+hud_lanes = true
+
 # Fold HUD-unrenderable precomposed Latin letters in street names down to
 # their base forms. The HUD ECU font only has glyphs below ~U+0800, so
 # any 3-byte-UTF-8 letter blanks out; for precomposed Latin letters (the
@@ -59,3 +65,21 @@ hud_fold_latin = false
 # show it). Has no effect on the maneuver arrow or distance.
 # Default: false
 force_street_name = false
+
+# --- aap_service (Android Auto 1.6 navigation -> HUD) -----------------
+
+# Advertise Android Auto GAL 1.6 to the phone instead of the OEM's 1.5.
+# At 1.5 the phone only sends the deprecated turn events; at 1.6 it sends
+# the full navigation protocol (maneuver, lanes, distance, ETA), which the
+# aap_service shim decodes and feeds to the HUD (via the hud / hud_transport
+# keys above).
+#
+# Requires libpatch-aap_service.so to be deployed and LD_PRELOAD'd into the
+# aap_service process (see the install docs). This key has NO effect unless
+# that shim is loaded — the other libraries ignore it.
+#
+# The GAL version is negotiated once per session, so a change takes effect on
+# the next Android Auto connection (restart jciAAPA or reconnect the phone).
+# When false the shim is inert and the unit behaves stock.
+# Default: false
+use_protocol_v1_6 = false

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,8 +51,20 @@ DBUSXX_LDFLAGS := --sysroot=$(SYSROOT) -static-libstdc++ \
                  -Wl,-Bstatic -ldbus-c++-1 -Wl,-Bdynamic \
                  -ldbus-1 -lpthread -lrt
 
+# --- host self-test (nav16_test) -------------------------------
+# nav16_test is a pure HOST build (plain g++, no ARM sysroot): it exercises the
+# AA 1.6 nav decoder via its public API by compiling test/nav16_test.cpp with
+# ../mazda/patches/blmjciaapa/hud/hud_nav16.cpp. -I points at the hud dir so
+# hud_nav16.h and (the header-only) hud_nav.h resolve. Returns non-zero on a
+# failed assertion so CI can gate on it.
+HOST_CXX      := g++
+HUD_DIR       := ../mazda/patches/blmjciaapa/hud
+# -I../mazda/patches: hud_nav16.cpp includes "common/aa_nav16_msg.h" (the
+# AA_NAV16_MSG_* msgId contract), same include root as the mazda build.
+HOST_CXXFLAGS := -std=gnu++11 -O2 -Wall -Wextra -I$(HUD_DIR) -I../mazda/patches
+
 BUILD := build
-TOOLS := gsi_test lane_test
+TOOLS := gsi_test lane_test nav16_test
 BINS  := $(addprefix $(BUILD)/,$(TOOLS))
 
 .PHONY: all clean $(TOOLS)
@@ -65,6 +77,10 @@ $(BUILD)/%: %.c | $(BUILD)
 # lane_test is C++ (dbus-c++). Explicit rule overrides the .c pattern.
 $(BUILD)/lane_test: lane_test.cpp | $(BUILD)
 	$(CXX) $(CXXFLAGS) $< -o $@ $(DBUSXX_LDFLAGS)
+
+# nav16_test is a HOST binary (plain g++) — runs on the build machine, not the CMU.
+$(BUILD)/nav16_test: nav16_test.cpp $(HUD_DIR)/hud_nav16.cpp | $(BUILD)
+	$(HOST_CXX) $(HOST_CXXFLAGS) $^ -o $@
 
 # Convenience: `make gsi_test` builds build/gsi_test.
 $(TOOLS): %: $(BUILD)/%

--- a/test/nav16_test.cpp
+++ b/test/nav16_test.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// nav16_test — host self-test for the AA GAL 1.6 nav decoder (hud_nav16).
+// Feeds hand-built synthetic 0x8006/0x8007 frames through the PUBLIC API and
+// asserts the decoded guidance/position/glyph/units. Returns non-zero on any
+// failed assertion so CI can gate on it. Pure host build (no ARM sysroot).
+
+#include "hud_nav16.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+static int g_fail = 0;
+
+// Parse a space-separated hex string ("80 06 0a ...") into a byte vector.
+static std::vector<uint8_t> hx(const char *s)
+{
+    std::vector<uint8_t> v;
+    unsigned b;
+    while (*s) {
+        if (sscanf(s, "%2x", &b) == 1) v.push_back((uint8_t)b);
+        s += (s[1] ? 2 : 1);
+        while (*s == ' ') ++s;
+    }
+    return v;
+}
+
+#define CHECK(cond, msg) do {                                            \
+        if (!(cond)) { printf("  FAIL: %s\n", (msg)); g_fail = 1; }      \
+        else         { printf("  ok:   %s\n", (msg)); }                  \
+    } while (0)
+
+#define CHECK_EQ_U(got, exp, msg) do {                                   \
+        unsigned long _g = (unsigned long)(got), _e = (unsigned long)(exp); \
+        if (_g != _e) { printf("  FAIL: %s (got %lu, want %lu)\n",       \
+                               (msg), _g, _e); g_fail = 1; }             \
+        else          { printf("  ok:   %s = %lu\n", (msg), _g); }       \
+    } while (0)
+
+#define CHECK_EQ_S(got, exp, msg) do {                                   \
+        if (strcmp((got), (exp)) != 0) {                                 \
+            printf("  FAIL: %s (got \"%s\", want \"%s\")\n",             \
+                   (msg), (got), (exp)); g_fail = 1; }                   \
+        else { printf("  ok:   %s = \"%s\"\n", (msg), (got)); }          \
+    } while (0)
+
+int main()
+{
+    char buf[512];
+
+    // --- DEPART, road "ROAD A", no lanes -------------------------------------
+    // expect maneuver=1 (DEPART) glyph=HUD_FLAG(12) road="ROAD A" lanes=0
+    {
+        printf("[1] DEPART, road \"ROAD A\", no lanes\n");
+        auto s = hx("80 06 0a 0e 0a 02 08 01 12 08 0a 06 52 4f 41 44 20 41");
+        AaGuidance g;
+        uint32_t id = hud_nav16_on_frame(s.data(), (int)s.size(), &g, nullptr);
+        hud_nav16_format_guidance(&g, buf, sizeof(buf));
+        printf("  %s\n", buf);
+        CHECK_EQ_U(id, 0x8006, "msgId");
+        CHECK_EQ_U(g.maneuver_type, 1u, "maneuver_type");
+        CHECK_EQ_U(hud_nav16_glyph(&g), 12u, "glyph (HUD_FLAG)");
+        CHECK_EQ_S(g.road, "ROAD A", "road");
+        CHECK_EQ_U(g.n_lanes, 0, "n_lanes");
+    }
+
+    // --- CurrentPosition: step 120 m "120", dest 1500 m "1,5" km, eta "12:34" -
+    {
+        printf("[2] CurrentPosition: step 120m, dest 1500m km, eta\n");
+        auto pz = hx("80 07 0a 0b 0a 09 08 78 12 03 31 32 30 18 01 12 13 0a 0a 08 dc 0b 12 03 31 2c 35 18 03 12 05 31 32 3a 33 34");
+        AaPosition p;
+        uint32_t id = hud_nav16_on_frame(pz.data(), (int)pz.size(), nullptr, &p);
+        hud_nav16_format_position(&p, buf, sizeof(buf));
+        printf("  %s\n", buf);
+        CHECK_EQ_U(id, 0x8007, "msgId");
+        CHECK(p.have_step, "have_step");
+        CHECK_EQ_U(p.step_meters, 120, "step_meters");
+        CHECK_EQ_S(p.step_display, "120", "step_display");
+        CHECK_EQ_U(p.step_units, 1u, "step_units (METERS)");
+        CHECK_EQ_U(aa_to_mazda_unit(p.step_units), 1u, "mazda step unit");
+        CHECK(p.have_dest, "have_dest");
+        CHECK_EQ_U(p.dest_meters, 1500, "dest_meters");
+        CHECK_EQ_S(p.dest_display, "1,5", "dest_display");
+        CHECK_EQ_U(p.dest_units, 3u, "dest_units (KILOMETERS)");
+        CHECK_EQ_U(aa_to_mazda_unit(p.dest_units), 3u, "mazda dest unit");
+        CHECK_EQ_S(p.eta, "12:34", "eta");
+        CHECK_EQ_U(parse_dist_x10(p.dest_display), 15, "parse_dist_x10(\"1,5\")");
+    }
+
+    // --- Junction WITH lanes ------------------------------------------------
+    // maneuver=8 TURN_NORMAL_RIGHT -> glyph=HUD_RIGHT(3), road "ROAD B",
+    // lane0=[STRAIGHT, NORMAL_RIGHT*hl], lane1=[NORMAL_RIGHT*hl]
+    //   expect L0 pres=0x022 hi=0x020, L1 pres=0x020 hi=0x020
+    {
+        printf("[3] Junction with lanes (TURN_NORMAL_RIGHT)\n");
+        auto j = hx("80 06 0a 22 0a 02 08 08 12 08 0a 06 52 4f 41 44 20 42 1a 0a 0a 02 08 01 0a 04 08 05 10 01 1a 06 0a 04 08 05 10 01");
+        AaGuidance g;
+        uint32_t id = hud_nav16_on_frame(j.data(), (int)j.size(), &g, nullptr);
+        hud_nav16_format_guidance(&g, buf, sizeof(buf));
+        printf("  %s\n", buf);
+        CHECK_EQ_U(id, 0x8006, "msgId");
+        CHECK_EQ_U(g.maneuver_type, 8u, "maneuver_type");
+        CHECK_EQ_U(hud_nav16_glyph(&g), 3u, "glyph (HUD_RIGHT)");
+        CHECK_EQ_S(g.road, "ROAD B", "road");
+        CHECK_EQ_U(g.n_lanes, 2, "n_lanes");
+        CHECK_EQ_U(g.lanes[0].present_mask, 0x022u, "L0 present_mask");
+        CHECK_EQ_U(g.lanes[0].highlight_mask, 0x020u, "L0 highlight_mask");
+        CHECK_EQ_U(g.lanes[1].present_mask, 0x020u, "L1 present_mask");
+        CHECK_EQ_U(g.lanes[1].highlight_mask, 0x020u, "L1 highlight_mask");
+    }
+
+    // --- Roundabout: maneuver=34 RA_ENTER_EXIT_CCW, exit angle 90 ------------
+    //   CCW = right-hand traffic -> base 37 + round(90/30)=3 -> glyph 40
+    {
+        printf("[4] Roundabout RA_ENTER_EXIT_CCW, angle 90\n");
+        auto r = hx("80 06 0a 06 0a 04 08 22 18 5a");
+        AaGuidance g;
+        uint32_t id = hud_nav16_on_frame(r.data(), (int)r.size(), &g, nullptr);
+        hud_nav16_format_guidance(&g, buf, sizeof(buf));
+        printf("  %s\n", buf);
+        CHECK_EQ_U(id, 0x8006, "msgId");
+        CHECK_EQ_U(g.maneuver_type, 34u, "maneuver_type");
+        CHECK_EQ_U(g.roundabout_exit_angle, 90, "roundabout_exit_angle");
+        CHECK_EQ_U(hud_nav16_glyph(&g), 40u, "glyph (roundabout 37+3)");
+    }
+
+    // --- NavigationStatus (0x8003): status field 1 varint --------------------
+    //   0x8003 body: field 1 (tag 0x08) varint = 2  -> status 2
+    {
+        printf("[5] NavigationStatus 0x8003 field 1\n");
+        auto st = hx("80 03 08 02");
+        int status = 999;
+        bool ok = hud_nav16_read_status(st.data(), (int)st.size(), &status);
+        printf("  read_status -> ok=%d status=%d\n", ok, status);
+        CHECK(ok, "read_status returned true");
+        CHECK_EQ_U(status, 2, "status value");
+    }
+
+    printf("\n%s\n", g_fail ? "RESULT: FAIL" : "RESULT: PASS");
+    return g_fail;
+}


### PR DESCRIPTION
Advertise Android Auto 1.6 so the phone sends full navigation guidance — maneuver, lanes, and distance/ETA — instead of the deprecated 1.5 turn events, and show it on the Active Driving Display. Opt-in via use_protocol_v1_6 (default false = stock 1.5).

The work splits across two processes: a new aap_service shim advertises 1.6 and relays the raw navigation frames, and the blmjciaapa shim decodes them and renders them through the existing HUD path. If the 1.6 setup doesn't take (shim not loaded, phone declines, etc.) it falls back to the stock 1.5 path so the HUD is never left dark.

- New aap_service shim + cross-process relay to blmjciaapa.
- New 1.6 navigation decoder and AA-to-Mazda glyph/unit mapping.
- Lane guidance on both HUD transports (svcnavi and vbs), gated by the new hud_lanes switch. Exact per-shape lane glyph still provisional.
- New config keys: use_protocol_v1_6 (default false) and hud_lanes (default true); hud_fold_latin default flipped to false.
- Install docs updated for the aap_service preload.
- Host self-test for the decoder (test/nav16_test), run in CI on every PR.