### PR TITLE
feat(hud): Fill all possible lane guidance options for table A and B HUD glyphs

### DIFF
--- a/mazda/patches/blmjciaapa/hud/hud.cpp
+++ b/mazda/patches/blmjciaapa/hud/hud.cpp
@@ -27,6 +27,7 @@
 #include "vbs_tx.h"
 #include "translit.h"   // hud_translit::fold() — precomposed-Latin street-name fold
 #include "hud_nav.h"    // compute_turn_icon() — AA turn fields -> Mazda HUD glyph
+#include "hud_lane.h"   // oem_lane_code_for_aa — AA lanes -> OEM lane codes
 
 #include <stdint.h>
 #include <string.h>
@@ -43,7 +44,7 @@ struct HudTransportOps {
     void (*status)(uint32_t status);
     void (*next_turn)(const char *road, uint32_t icon);
     void (*distance)(int32_t dist_dec, uint8_t dist_unit);
-    void (*lanes)(const AaLane *lanes, uint8_t n);   // encoded per-transport below
+    void (*lanes)(const uint8_t *codes);             // raw setter; fed by emit_lane_codes
 };
 
 // Per-transport next_turn adapters. Today both just forward the resolved glyph +
@@ -59,44 +60,28 @@ void vbs_next_turn_adapter(const char *road, uint32_t icon)
     vbs_tx_next_turn(road, icon);
 }
 
-// Encode the decoded 1.6 lanes to the 8-slot Mazda HUD lane array, LEFT to
-// RIGHT: a present lane is MARKED if any of its arrows is highlighted
-// (recommended), else UNMARKED; absent slots are HIDDEN (canonical 0). (Per-shape
-// glyph detail is TBD on-car.)
-void nav16_encode_lanes(const AaLane *lanes, int n, uint8_t out[HUD_NAV16_MAX_LANES])
+// Encode the decoded 1.6 lanes to 8 OEM lane CODES (0..70), LEFT to RIGHT; an
+// absent slot is HIDDEN (canonical 0 == OEM_LANE_NONE).
+// hud_lane.h owns the full AA-shape -> OEM-code mapping: single arrows, the
+// multi-direction combos, and the recommended-direction detail codes that pick
+// out the highlighted arrow within a combo.
+void nav16_encode_lane_codes(const AaLane *lanes, int n, uint8_t out[HUD_NAV16_MAX_LANES])
 {
     for (int i = 0; i < HUD_NAV16_MAX_LANES; ++i) {
         out[i] = (lanes && i < n)
-                     ? (uint8_t)(lanes[i].highlight_mask ? HUD_LANE_MARKED
-                                                         : HUD_LANE_UNMARKED)
-                     : HUD_LANE_HIDDEN;
+                     ? (uint8_t)oem_lane_code_for_aa(lanes[i].present_mask,
+                                                     lanes[i].highlight_mask)
+                     : (uint8_t)OEM_LANE_NONE;   // 0 = hidden
     }
-}
-
-// Per-transport lane adapters: encode the decoded AA lanes to the 8-slot Mazda
-// byte array for THIS backend, then hand the bytes to its setter. Same seam as
-// the next_turn adapters — today both encode identically (canonical hidden 0;
-// vbs remaps to 0xFF at its own wire), but each could diverge.
-void svcnavi_lanes_adapter(const AaLane *lanes, uint8_t n)
-{
-    uint8_t lane_bytes[HUD_NAV16_MAX_LANES];
-    nav16_encode_lanes(lanes, n, lane_bytes);
-    svcnavi_tx_lanes(lane_bytes);
-}
-void vbs_lanes_adapter(const AaLane *lanes, uint8_t n)
-{
-    uint8_t lane_bytes[HUD_NAV16_MAX_LANES];
-    nav16_encode_lanes(lanes, n, lane_bytes);
-    vbs_tx_lanes(lane_bytes);
 }
 
 const HudTransportOps kSvcnaviOps = {
     &svcnavi_tx_start, &svcnavi_tx_stop, &svcnavi_tx_status,
-    &svcnavi_next_turn_adapter, &svcnavi_tx_distance, &svcnavi_lanes_adapter,
+    &svcnavi_next_turn_adapter, &svcnavi_tx_distance, &svcnavi_tx_lanes,
 };
 const HudTransportOps kVbsOps = {
     &vbs_tx_start, &vbs_tx_stop, &vbs_tx_status,
-    &vbs_next_turn_adapter, &vbs_tx_distance, &vbs_lanes_adapter,
+    &vbs_next_turn_adapter, &vbs_tx_distance, &vbs_tx_lanes,
 };
 
 // The active backend. Bound once in hud_tx_start() (the first transport
@@ -627,12 +612,15 @@ static void nav16_emit_if_changed()
     AaNav16HudState &acc = g_nav16_acc;
     if (g_nav16_have_last && memcmp(&acc, &g_nav16_last, sizeof(acc)) == 0) return;
     // acc holds Mazda-domain values (resolved glyph, folded road, value*10
-    // distance in the Mazda unit) plus the decoded lanes; the per-transport lane
-    // adapter encodes them to HUD bytes. The rx thread is the sole writer under
-    // v1.6, so the transport's snapshot merge is race-free.
+    // distance in the Mazda unit) plus the decoded lanes; we encode the lanes to
+    // OEM codes here (each transport maps code->glyph on its own wire as needed).
+    // The rx thread is the sole writer under v1.6, so the transport's snapshot
+    // merge is race-free.
+    uint8_t lane_codes[HUD_NAV16_MAX_LANES];
+    nav16_encode_lane_codes(acc.lanes, acc.n_lanes, lane_codes);
     g_tx->next_turn(acc.road, acc.glyph);
     g_tx->distance(acc.dist_dec, acc.dist_unit);
-    g_tx->lanes(acc.lanes, acc.n_lanes);
+    g_tx->lanes(lane_codes);
     g_nav16_last      = acc;
     g_nav16_have_last = true;
 }

--- a/mazda/patches/blmjciaapa/hud/hud_lane.h
+++ b/mazda/patches/blmjciaapa/hud/hud_lane.h
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// OEM head-unit lane-guidance codes, and the Android Auto -> OEM code mapping.
+//
+// When Android Auto shows lane guidance (the row of little arrows before a
+// junction), we forward it to the car by sending one numeric "lane code" per lane
+// to the head unit's navigation service. That service owns the actual cluster
+// artwork: it turns each code into a glyph for whichever instrument cluster is
+// fitted (a basic cluster draws a coarser set of arrows, an extended one draws
+// more distinct arrows). That choice is made by the head unit, downstream of us,
+// so this module's only job is to pick the right code for a lane — it never deals
+// in glyphs.
+//
+// How the 0..70 code space is laid out:
+//   - Every lane shape has an "arrow" number:
+//       0        empty (no lane)
+//       1        straight
+//       2..7     the six turn arrows (slight/normal/sharp, right and left)
+//       8..19    multi-direction lanes (a lane you may take several ways)
+//       20..22   HOV / bus / taxi lanes
+//   - A RECOMMENDED lane (the one Android Auto highlights as yours) is sent as the
+//     arrow number itself, 1..48.
+//   - A NON-recommended lane (a neighbouring lane, drawn greyed) is sent as
+//     arrow + 48, i.e. 49..70.
+//   - An empty lane is 0.
+//   - Codes 23..48 are a finer recommended form: a multi-direction lane in which
+//     exactly one of its directions is the highlighted (recommended) one.
+//
+// This lives in its own header, separate from the version-specific Android Auto
+// nav decoder, because the code space is the head unit's and does not depend on
+// the Android Auto protocol version that produced the lanes.
+//
+// Header-only: plain enums and pure inline functions, no state and no I/O.
+
+#ifndef LIBPATCH_BLMJCIAAPA_HUD_LANE_H
+#define LIBPATCH_BLMJCIAAPA_HUD_LANE_H
+
+#include <stdint.h>
+
+// === Android Auto lane-direction shapes =======================================
+// The shape of one arrow within an Android Auto lane (its LaneDirection.shape).
+// A single lane may carry several of these at once (a multi-direction lane).
+enum AaLaneShape : uint8_t {
+    AA_SHAPE_UNKNOWN      = 0,
+    AA_SHAPE_STRAIGHT     = 1,
+    AA_SHAPE_SLIGHT_LEFT  = 2,
+    AA_SHAPE_SLIGHT_RIGHT = 3,
+    AA_SHAPE_NORMAL_LEFT  = 4,
+    AA_SHAPE_NORMAL_RIGHT = 5,
+    AA_SHAPE_SHARP_LEFT   = 6,
+    AA_SHAPE_SHARP_RIGHT  = 7,
+    AA_SHAPE_U_TURN_LEFT  = 8,
+    AA_SHAPE_U_TURN_RIGHT = 9,
+};
+
+// === OEM lane codes (0..70) ===================================================
+// The value sent to the head unit for one lane. Codes 1..22 are the recommended
+// (your) lane; 23..48 are the recommended lane with one direction singled out;
+// 49..70 are the non-recommended (greyed neighbour) lanes, and are simply the
+// matching 1..22 shape plus 48.
+enum OemLaneCode : uint8_t {
+    OEM_LANE_NONE                      =  0, // empty / no lane
+
+    // -- recommended lane, one arrow --
+    OEM_LANE_STRAIGHT                  =  1, // straight
+    OEM_LANE_SLIGHT_RIGHT              =  2, // slight right
+    OEM_LANE_RIGHT                     =  3, // right
+    OEM_LANE_SHARP_RIGHT               =  4, // sharp right
+    OEM_LANE_SLIGHT_LEFT               =  5, // slight left
+    OEM_LANE_LEFT                      =  6, // left
+    OEM_LANE_SHARP_LEFT                =  7, // sharp left
+
+    // -- recommended lane, multiple arrows (you may take it several ways) --
+    OEM_LANE_COMBO_STRAIGHT_SLIGHT_R   =  8, // straight or slight-right
+    OEM_LANE_COMBO_STRAIGHT_SLIGHT_L   =  9, // straight or slight-left
+    OEM_LANE_COMBO_SLIGHT_L_S_SLIGHT_R = 10, // slight-left, straight or slight-right
+    OEM_LANE_COMBO_STRAIGHT_RIGHT      = 11, // straight or right
+    OEM_LANE_COMBO_STRAIGHT_LEFT       = 12, // straight or left
+    OEM_LANE_COMBO_LEFT_STRAIGHT_RIGHT = 13, // left, straight or right
+    OEM_LANE_COMBO_SLIGHT_R_SHARP_R    = 14, // slight-right or sharp-right
+    OEM_LANE_COMBO_SLIGHT_L_SHARP_L    = 15, // slight-left or sharp-left
+    OEM_LANE_COMBO_FORK                = 16, // fork: slight-left or slight-right
+    OEM_LANE_COMBO_17_ALIAS_11         = 17, // same as 11 (straight or right)
+    OEM_LANE_COMBO_18_ALIAS_12         = 18, // same as 12 (straight or left)
+    OEM_LANE_COMBO_LEFT_RIGHT_T        = 19, // left or right (T-junction)
+
+    // -- recommended lane, special lane types --
+    OEM_LANE_HOV                       = 20, // HOV / carpool lane
+    OEM_LANE_BUS                       = 21, // bus lane
+    OEM_LANE_TAXI                      = 22, // taxi lane
+
+    // -- recommended multi-direction lane, one direction singled out --
+    OEM_LANE_REC_C8_STRAIGHT           = 23, // straight-or-slight-right lane, take straight
+    OEM_LANE_REC_C8_SLIGHT_R           = 24, // straight-or-slight-right lane, take slight-right
+    OEM_LANE_REC_C9_STRAIGHT           = 25, // straight-or-slight-left lane, take straight
+    OEM_LANE_REC_C9_SLIGHT_L           = 26, // straight-or-slight-left lane, take slight-left
+    OEM_LANE_REC_C10_STRAIGHT          = 27, // slight-left/straight/slight-right lane, take straight
+    OEM_LANE_REC_C10_SLIGHT_L          = 28, // slight-left/straight/slight-right lane, take slight-left
+    OEM_LANE_REC_C10_SLIGHT_R          = 29, // slight-left/straight/slight-right lane, take slight-right
+    OEM_LANE_REC_C11_STRAIGHT          = 30, // straight-or-right lane, take straight
+    OEM_LANE_REC_C11_RIGHT             = 31, // straight-or-right lane, take right
+    OEM_LANE_REC_C12_STRAIGHT          = 32, // straight-or-left lane, take straight
+    OEM_LANE_REC_C12_LEFT              = 33, // straight-or-left lane, take left
+    OEM_LANE_REC_C13_STRAIGHT          = 34, // left/straight/right lane, take straight
+    OEM_LANE_REC_C13_LEFT              = 35, // left/straight/right lane, take left
+    OEM_LANE_REC_C13_RIGHT             = 36, // left/straight/right lane, take right
+    OEM_LANE_REC_C14_SLIGHT_R          = 37, // slight-right-or-sharp-right lane, take slight-right
+    OEM_LANE_REC_C14_SHARP_R           = 38, // slight-right-or-sharp-right lane, take sharp-right
+    OEM_LANE_REC_C15_SLIGHT_L          = 39, // slight-left-or-sharp-left lane, take slight-left
+    OEM_LANE_REC_C15_SHARP_L           = 40, // slight-left-or-sharp-left lane, take sharp-left
+    OEM_LANE_REC_C16_SLIGHT_L          = 41, // fork lane, take slight-left
+    OEM_LANE_REC_C16_SLIGHT_R          = 42, // fork lane, take slight-right
+    OEM_LANE_REC_43_ALIAS_30           = 43, // same as 30
+    OEM_LANE_REC_44_ALIAS_31           = 44, // same as 31
+    OEM_LANE_REC_45_ALIAS_32           = 45, // same as 32
+    OEM_LANE_REC_46_ALIAS_33           = 46, // same as 33
+    OEM_LANE_REC_C19_LEFT              = 47, // left-or-right lane, take left
+    OEM_LANE_REC_C19_RIGHT             = 48, // left-or-right lane, take right
+
+    // -- non-recommended (greyed neighbour) lanes: the 1..22 shapes, plus 48 --
+    OEM_LANE_NR_STRAIGHT               = 49, // straight
+    OEM_LANE_NR_SLIGHT_RIGHT           = 50, // slight right
+    OEM_LANE_NR_RIGHT                  = 51, // right
+    OEM_LANE_NR_SHARP_RIGHT            = 52, // sharp right
+    OEM_LANE_NR_SLIGHT_LEFT            = 53, // slight left
+    OEM_LANE_NR_LEFT                   = 54, // left
+    OEM_LANE_NR_SHARP_LEFT             = 55, // sharp left
+    OEM_LANE_NR_COMBO_STRAIGHT_SLIGHT_R= 56, // straight or slight-right
+    OEM_LANE_NR_COMBO_STRAIGHT_SLIGHT_L= 57, // straight or slight-left
+    OEM_LANE_NR_COMBO_SLIGHT_L_S_SLIGHT_R=58,// slight-left, straight or slight-right
+    OEM_LANE_NR_COMBO_STRAIGHT_RIGHT   = 59, // straight or right
+    OEM_LANE_NR_COMBO_STRAIGHT_LEFT    = 60, // straight or left
+    OEM_LANE_NR_COMBO_LEFT_STRAIGHT_RIGHT=61,// left, straight or right
+    OEM_LANE_NR_COMBO_SLIGHT_R_SHARP_R = 62, // slight-right or sharp-right
+    OEM_LANE_NR_COMBO_SLIGHT_L_SHARP_L = 63, // slight-left or sharp-left
+    OEM_LANE_NR_COMBO_FORK             = 64, // fork: slight-left or slight-right
+    OEM_LANE_NR_COMBO_17_ALIAS_11      = 65, // same as 59 (straight or right)
+    OEM_LANE_NR_COMBO_18_ALIAS_12      = 66, // same as 60 (straight or left)
+    OEM_LANE_NR_COMBO_LEFT_RIGHT_T     = 67, // left or right (T-junction)
+    OEM_LANE_NR_HOV                    = 68, // HOV / carpool lane
+    OEM_LANE_NR_BUS                    = 69, // bus lane
+    OEM_LANE_NR_TAXI                   = 70, // taxi lane
+};
+
+// The "no lane in this slot" value depends on the transport that carries the
+// codes: the guidance-signal path treats 0 as empty, while the direct lane-request
+// path uses 0xFF. This module works in the code domain where empty is 0; the
+// caller substitutes its own sentinel for empty slots if it needs a different one.
+
+// === Android Auto lane -> OEM code ============================================
+
+// A single turn direction, as a bit, so a multi-direction lane can be described
+// as a set of directions and matched against the known combinations below.
+enum {
+    OD_STRAIGHT = 1u << 0,
+    OD_SLIGHT_R = 1u << 1,
+    OD_RIGHT    = 1u << 2,
+    OD_SHARP_R  = 1u << 3,
+    OD_SLIGHT_L = 1u << 4,
+    OD_LEFT     = 1u << 5,
+    OD_SHARP_L  = 1u << 6,
+};
+
+// Android Auto shape -> its direction bit (see OD_* above).
+inline unsigned aa_shape_to_oem_dir(uint8_t shape)
+{
+    switch (shape) {
+    case AA_SHAPE_STRAIGHT:     return OD_STRAIGHT;
+    case AA_SHAPE_SLIGHT_RIGHT: return OD_SLIGHT_R;
+    case AA_SHAPE_NORMAL_RIGHT: return OD_RIGHT;
+    case AA_SHAPE_SHARP_RIGHT:  return OD_SHARP_R;
+    case AA_SHAPE_U_TURN_RIGHT: return OD_SHARP_R;  // U-turn -> sharp right
+    case AA_SHAPE_SLIGHT_LEFT:  return OD_SLIGHT_L;
+    case AA_SHAPE_NORMAL_LEFT:  return OD_LEFT;
+    case AA_SHAPE_SHARP_LEFT:   return OD_SHARP_L;
+    case AA_SHAPE_U_TURN_LEFT:  return OD_SHARP_L;  // U-turn -> sharp left
+    default:                    return OD_STRAIGHT; // unknown
+    }
+}
+
+// Non-recommended (greyed neighbour) lane codes are the recommended code + this.
+static constexpr uint8_t OEM_LANE_NONREC_OFFSET = 48;
+
+// A set of direction bits -> the recommended OEM code for that lane shape.
+// One direction -> a single-arrow code; a recognised combination -> a combo code;
+// anything not recognised -> OEM_LANE_NONE (the caller then picks a single arrow).
+inline OemLaneCode oem_base_code_for_dirs(unsigned d)
+{
+    switch (d) {
+    case OD_STRAIGHT:                             return OEM_LANE_STRAIGHT;
+    case OD_SLIGHT_R:                             return OEM_LANE_SLIGHT_RIGHT;
+    case OD_RIGHT:                                return OEM_LANE_RIGHT;
+    case OD_SHARP_R:                              return OEM_LANE_SHARP_RIGHT;
+    case OD_SLIGHT_L:                             return OEM_LANE_SLIGHT_LEFT;
+    case OD_LEFT:                                 return OEM_LANE_LEFT;
+    case OD_SHARP_L:                              return OEM_LANE_SHARP_LEFT;
+    case OD_STRAIGHT | OD_SLIGHT_R:               return OEM_LANE_COMBO_STRAIGHT_SLIGHT_R;
+    case OD_STRAIGHT | OD_SLIGHT_L:               return OEM_LANE_COMBO_STRAIGHT_SLIGHT_L;
+    case OD_SLIGHT_L | OD_STRAIGHT | OD_SLIGHT_R: return OEM_LANE_COMBO_SLIGHT_L_S_SLIGHT_R;
+    case OD_STRAIGHT | OD_RIGHT:                  return OEM_LANE_COMBO_STRAIGHT_RIGHT;
+    case OD_STRAIGHT | OD_LEFT:                   return OEM_LANE_COMBO_STRAIGHT_LEFT;
+    case OD_LEFT | OD_STRAIGHT | OD_RIGHT:        return OEM_LANE_COMBO_LEFT_STRAIGHT_RIGHT;
+    case OD_SLIGHT_R | OD_SHARP_R:                return OEM_LANE_COMBO_SLIGHT_R_SHARP_R;
+    case OD_SLIGHT_L | OD_SHARP_L:                return OEM_LANE_COMBO_SLIGHT_L_SHARP_L;
+    case OD_SLIGHT_L | OD_SLIGHT_R:               return OEM_LANE_COMBO_FORK;
+    case OD_LEFT | OD_RIGHT:                      return OEM_LANE_COMBO_LEFT_RIGHT_T;
+    default:                                      return OEM_LANE_NONE;
+    }
+}
+
+// A recommended combo lane in which exactly one direction is highlighted -> the
+// finer "take this direction" code. OEM_LANE_NONE if `base` is not a combo, or has
+// no code for that highlighted direction.
+inline OemLaneCode oem_detail_code(OemLaneCode base, unsigned hl)
+{
+    switch (base) {
+    case OEM_LANE_COMBO_STRAIGHT_SLIGHT_R:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C8_STRAIGHT
+             : hl == OD_SLIGHT_R ? OEM_LANE_REC_C8_SLIGHT_R  : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_STRAIGHT_SLIGHT_L:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C9_STRAIGHT
+             : hl == OD_SLIGHT_L ? OEM_LANE_REC_C9_SLIGHT_L  : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_SLIGHT_L_S_SLIGHT_R:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C10_STRAIGHT
+             : hl == OD_SLIGHT_L ? OEM_LANE_REC_C10_SLIGHT_L
+             : hl == OD_SLIGHT_R ? OEM_LANE_REC_C10_SLIGHT_R : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_STRAIGHT_RIGHT:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C11_STRAIGHT
+             : hl == OD_RIGHT    ? OEM_LANE_REC_C11_RIGHT    : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_STRAIGHT_LEFT:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C12_STRAIGHT
+             : hl == OD_LEFT     ? OEM_LANE_REC_C12_LEFT     : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_LEFT_STRAIGHT_RIGHT:
+        return hl == OD_STRAIGHT ? OEM_LANE_REC_C13_STRAIGHT
+             : hl == OD_LEFT     ? OEM_LANE_REC_C13_LEFT
+             : hl == OD_RIGHT    ? OEM_LANE_REC_C13_RIGHT    : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_SLIGHT_R_SHARP_R:
+        return hl == OD_SLIGHT_R ? OEM_LANE_REC_C14_SLIGHT_R
+             : hl == OD_SHARP_R  ? OEM_LANE_REC_C14_SHARP_R  : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_SLIGHT_L_SHARP_L:
+        return hl == OD_SLIGHT_L ? OEM_LANE_REC_C15_SLIGHT_L
+             : hl == OD_SHARP_L  ? OEM_LANE_REC_C15_SHARP_L  : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_FORK:
+        return hl == OD_SLIGHT_L ? OEM_LANE_REC_C16_SLIGHT_L
+             : hl == OD_SLIGHT_R ? OEM_LANE_REC_C16_SLIGHT_R : OEM_LANE_NONE;
+    case OEM_LANE_COMBO_LEFT_RIGHT_T:
+        return hl == OD_LEFT     ? OEM_LANE_REC_C19_LEFT
+             : hl == OD_RIGHT    ? OEM_LANE_REC_C19_RIGHT    : OEM_LANE_NONE;
+    default:
+        return OEM_LANE_NONE;
+    }
+}
+
+// Turn one Android Auto lane into its OEM code.
+//
+// Inputs are bitmasks over AaLaneShape: bit s is set if a direction with shape s
+// is present / highlighted in this lane. A lane counts as recommended (yours) if
+// any of its directions is highlighted. Result:
+//   - no directions                                -> OEM_LANE_NONE
+//   - recommended combo, one direction highlighted -> a detail code (23..48)
+//   - recommended                                  -> the base code (1..22)
+//   - not recommended                              -> base + 48 (49..70)
+inline OemLaneCode oem_lane_code_for_aa(uint16_t present_shapes, uint16_t highlight_shapes)
+{
+    unsigned present = 0, hl = 0;
+    for (uint8_t s = 0; s <= 9; ++s) {
+        const uint16_t bit = (uint16_t)(1u << s);
+        if (present_shapes   & bit) present |= aa_shape_to_oem_dir(s);
+        if (highlight_shapes & bit) hl      |= aa_shape_to_oem_dir(s);
+    }
+    if (!present) return OEM_LANE_NONE;
+
+    const bool  rec  = (hl != 0);
+    OemLaneCode base = oem_base_code_for_dirs(present);
+
+    // A recommended combo lane with exactly one highlighted direction gets the
+    // finer "take this direction" code.
+    const bool one_hl = hl && ((hl & (hl - 1)) == 0);
+    if (rec && one_hl) {
+        const OemLaneCode d = oem_detail_code(base, hl);
+        if (d != OEM_LANE_NONE) return d;
+    }
+
+    // A direction set with no combined code: fall back to a single arrow — the
+    // highlighted direction if there is one, otherwise the first present.
+    if (base == OEM_LANE_NONE) {
+        const unsigned pick = one_hl ? hl : (present & (0u - present));
+        base = oem_base_code_for_dirs(pick);
+        if (base == OEM_LANE_NONE) base = OEM_LANE_STRAIGHT;  // last resort
+    }
+
+    return rec ? base : (OemLaneCode)(base + OEM_LANE_NONREC_OFFSET);
+}
+
+// === OEM code -> HUD glyph (svcjcinavi's g_arrLaneInfoMapping) ================
+//
+// svcjcinavi::NAVI_SendHUDGuidaceDataToVBS turns each OEM lane code (0..70) into a
+// cluster glyph via g_arrLaneInfoMapping, then ships the glyph bytes on
+// VBS_NAVI_SetRecommLaneReq. Table A = basic cluster (glyphs 0..35, collapses
+// detail); table B = extended cluster (glyphs 0..62). Which is live is chosen by
+// CMU-control sub-id 0x18 (meter ECU / as-built).
+//
+// The svcnavi transport hands svcjcinavi the CODE and lets it do this. The DIRECT
+// VBS transport bypasses svcjcinavi, so it must apply the same map itself before
+// SetRecommLaneReq — that's what oem_lane_glyph() is for.
+enum OemLaneTable { OEM_LANE_TABLE_A = 0, OEM_LANE_TABLE_B = 1 };
+
+// code (0..70) -> cluster glyph for the chosen table; out-of-range -> 0 (empty).
+// Tables are byte-exact from svcjcinavi.so .data (A @ vaddr 0xaa058, B @ 0xaa174;
+// 71 entries each, all values <= 62). Function-local so a single shared copy.
+inline uint8_t oem_lane_glyph(OemLaneCode code, OemLaneTable table)
+{
+    static const uint8_t A[71] = {
+         0, 1, 2, 2, 3, 4, 4, 5, 1, 1, 1, 1,
+         1, 1, 1, 1, 1, 1, 1, 1,19,20,21, 6,
+         7, 8, 9,10,11,12, 6, 7, 8, 9,10,15,
+        13,13,14,15,16,17,18, 6, 7, 8, 9, 9,
+         7,22,23,23,24,25,25,26,27,28,29,27,
+        28,29,30,31,32,30,31,32,33,34,35
+    };
+    static const uint8_t B[71] = {
+         0, 1, 2,46, 3, 4,47, 5,40,43,36,41,
+        44,37,42,45,38,41,44,39,19,20,21, 6,
+         7, 8, 9,10,11,12,48,49,51,52,54,56,
+        55,13,14,15,16,17,18,48,49,51,52,53,
+        50,22,23,57,24,25,58,26,27,28,29,59,
+        60,61,30,31,32,59,60,62,33,34,35
+    };
+    const unsigned c = (unsigned)code;
+    if (c > 70) return 0;
+    return table == OEM_LANE_TABLE_B ? B[c] : A[c];
+}
+
+#endif // LIBPATCH_BLMJCIAAPA_HUD_LANE_H

--- a/mazda/patches/blmjciaapa/hud/hud_nav.h
+++ b/mazda/patches/blmjciaapa/hud/hud_nav.h
@@ -144,21 +144,6 @@ inline uint8_t map_distance_unit(uint32_t android_unit)
     }
 }
 
-// === Mazda HUD recommended-lane byte codes ====================
-//
-// Per-slot value in the HUD's 8-lane array. hud.cpp encodes the decoded AA
-// lanes to these before handing them to a transport (Mazda domain, like the
-// glyph/unit maps above). marked/unmarked are shared by both transports; the
-// hidden sentinel is canonical 0 here, so a zero-init / cleared snapshot is
-// "all hidden" for free — the vbs transport remaps 0 -> 0xFF for
-// VBS_NAVI_SetRecommLaneReq, while svcnavi's GuidanceChangedForHUD takes 0
-// as-is (its handler validates each lane arg to 0..0x46).
-enum {
-    HUD_LANE_HIDDEN   = 0,     // no lane in this slot
-    HUD_LANE_UNMARKED = 1,     // a lane, not the recommended one
-    HUD_LANE_MARKED   = 22,    // the recommended lane
-};
-
 // === Turn-icon resolution =====================================
 //
 // Resolve the HUD glyph from the proto turn fields. Pure function of

--- a/mazda/patches/blmjciaapa/hud/svcnavi_tx.cpp
+++ b/mazda/patches/blmjciaapa/hud/svcnavi_tx.cpp
@@ -27,6 +27,7 @@
 #include "../log.h"
 #include "svcnavi_tx.h"
 #include "hud_nav.h"
+#include "hud_lane.h"
 #include "../oem/libdbus.h"
 #include "../../common/oem/vbs_navi_hud.h"   // kAapSpeedSentinel (shared with svcjcinavi)
 
@@ -70,7 +71,7 @@ struct NaviSnapshot {
     uint32_t dir_icon;       // Mazda HUD maneuver glyph (resolved by hud.cpp)
     int32_t  distance_dec;   // value * 10
     uint8_t  distance_unit;  // mapped to Mazda enum
-    uint8_t  lanes[8];       // Mazda lane bytes: 0=hidden, 1=unmarked, 22=marked
+    uint8_t  lanes[8];       // OEM lane codes: 0=hidden, 1..70 (svcjcinavi maps code->glyph)
 };
 
 NaviSnapshot            g_snapshot = {};
@@ -387,7 +388,7 @@ void svcnavi_tx_lanes(const uint8_t *lanes)
     if (lanes) {
         std::memcpy(g_snapshot.lanes, lanes, sizeof(g_snapshot.lanes));
     } else {
-        std::memset(g_snapshot.lanes, HUD_LANE_HIDDEN, sizeof(g_snapshot.lanes));
+        std::memset(g_snapshot.lanes, OEM_LANE_NONE, sizeof(g_snapshot.lanes));
     }
     seqlock_end();
 }

--- a/mazda/patches/blmjciaapa/hud/svcnavi_tx.h
+++ b/mazda/patches/blmjciaapa/hud/svcnavi_tx.h
@@ -73,8 +73,9 @@ void svcnavi_tx_next_turn(const char *road_name, uint32_t dir_icon);
 void svcnavi_tx_distance(int32_t dist_dec, uint8_t dist_unit);
 
 // Recommended-lane array (GAL 1.6 only; the 1.5 path never sends lanes). Exactly
-// 8 Mazda lane bytes, LEFT to RIGHT (0=hidden, 1=unmarked, 22=marked; hud.cpp
-// encodes them), forwarded to lane0..7 of GuidanceChangedForHUD.
+// 8 OEM lane CODES (0..70; 0=hidden), LEFT to RIGHT — hud.cpp encodes them and
+// svcjcinavi maps each code to a cluster glyph itself. Forwarded verbatim to
+// lane0..7 of GuidanceChangedForHUD.
 void svcnavi_tx_lanes(const uint8_t *lanes);
   
 #endif // LIBPATCH_BLMJCIAAPA_HUD_SVCNAVI_TX_H

--- a/mazda/patches/blmjciaapa/hud/vbs_tx.cpp
+++ b/mazda/patches/blmjciaapa/hud/vbs_tx.cpp
@@ -40,6 +40,7 @@
 #include "../log.h"
 #include "vbs_tx.h"
 #include "hud_nav.h"
+#include "hud_lane.h"   // oem_lane_glyph — OEM lane code -> cluster glyph (mapped on this wire)
 #include "../oem/libjcivbsnaviclient.h"
 
 #include <chrono>
@@ -66,6 +67,11 @@ namespace {
 // oem/libjcivbsnaviclient.{h,cpp}.
 constexpr const char *kBusName = "com.jci.aapa.hud";
 
+// Empty-slot sentinel for VBS_NAVI_SetRecommLaneReq's (ay) lane array: the OEM
+// method hides a slot with this byte on the wire. VBS-only — the canonical
+// snapshot hidden value is OEM_LANE_NONE (0); we remap 0 -> this at emit.
+constexpr uint8_t kVbsLaneHidden = 0xFF;
+
 // map_distance_unit() (distance-unit enum) comes from hud_nav.h, shared with
 // the svcnavi transport. The turn-icon mapping (kTurnIcons / compute_turn_icon)
 // now lives in hud.cpp — this transport receives an already-resolved glyph.
@@ -81,7 +87,7 @@ struct NaviSnapshot {
     uint32_t dir_icon;           // Mazda HUD maneuver glyph (resolved by hud.cpp)
     int32_t  distance_dec;       // value * 10 (one decimal place)
     uint8_t  distance_unit;      // ALREADY mapped to Mazda enum
-    uint8_t  lanes[8];           // Mazda lane bytes: 0=hidden, 1=unmarked, 22=marked
+    uint8_t  lanes[8];           // OEM lane codes: 0=hidden, 1..70 (mapped to glyphs at emit)
 };
 
 NaviSnapshot           g_snapshot   = {};
@@ -203,7 +209,7 @@ void send_one(const NaviSnapshot &cur,
     // shown->hidden transitions are already covered by lanes_changed.
     bool cur_lanes_visible = false;
     for (size_t i = 0; i < sizeof(cur.lanes); ++i) {
-        if (cur.lanes[i] != HUD_LANE_HIDDEN) { cur_lanes_visible = true; break; }
+        if (cur.lanes[i] != OEM_LANE_NONE) { cur_lanes_visible = true; break; }
     }
     bool send_lanes = lanes_changed || (send_msg2 && cur_lanes_visible);
 
@@ -250,14 +256,19 @@ void send_one(const NaviSnapshot &cur,
     if (send_lanes) {
         // Same sync generation as the disp/msg2 just sent (send_msg2 is forced
         // true whenever lanes go out, so sync was bumped above). The HUD ties the
-        // lane array to that generation. SetRecommLaneReq hides a slot with 0xFF,
-        // so remap our canonical hidden (0) to it; the marked/unmarked codes go on
-        // the wire unchanged. The OEM setter dereferences both middle args (see
-        // libjcivbsnaviclient.h), so it gets pointers to the data pointer and the
-        // count.
+        // lane array to that generation. This transport bypasses svcjcinavi, so it
+        // maps each OEM lane code to its cluster glyph here (Table A for now —
+        // svcjcinavi's own static default, which renders on any cluster), then hides
+        // empty slots with kVbsLaneHidden (0xFF), SetRecommLaneReq's per-slot hide
+        // code. The OEM setter dereferences both middle args (see
+        // libjcivbsnaviclient.h), so it gets pointers to the data pointer and the count.
         uint8_t wire[8];
-        for (int i = 0; i < 8; ++i)
-            wire[i] = (cur.lanes[i] == HUD_LANE_HIDDEN) ? 0xFF : cur.lanes[i];
+        for (int i = 0; i < 8; ++i) {
+            uint8_t code = cur.lanes[i];   // OEM lane code, 0 = hidden
+            wire[i] = (code == OEM_LANE_NONE)
+                          ? kVbsLaneHidden
+                          : oem_lane_glyph((OemLaneCode)code, OEM_LANE_TABLE_A);
+        }
         const uint8_t *lane_data  = wire;
         const uint32_t lane_count = sizeof(wire);
         int rc = VBS_NAVI_SetRecommLaneReq(g_conn, &lane_data, &lane_count,
@@ -350,11 +361,11 @@ void sender_teardown()
         } else {
             LOGD("hud sender: sent HUD clear frame");
         }
-        // Hide any lanes a 1.6 session left on the HUD (all slots hidden). 0xFF
-        // is SetRecommLaneReq's per-slot hide code.
+        // Hide any lanes a 1.6 session left on the HUD (all slots hidden).
+        // kVbsLaneHidden (0xFF) is SetRecommLaneReq's per-slot hide code.
         {
             uint8_t clear_lanes[8];
-            std::memset(clear_lanes, 0xFF, sizeof(clear_lanes));
+            std::memset(clear_lanes, kVbsLaneHidden, sizeof(clear_lanes));
             const uint8_t *lane_data  = clear_lanes;
             const uint32_t lane_count = sizeof(clear_lanes);
             VBS_NAVI_SetRecommLaneReq(g_conn, &lane_data, &lane_count,
@@ -582,7 +593,7 @@ void vbs_tx_lanes(const uint8_t *lanes)
     if (lanes) {
         std::memcpy(g_snapshot.lanes, lanes, sizeof(g_snapshot.lanes));
     } else {
-        std::memset(g_snapshot.lanes, HUD_LANE_HIDDEN, sizeof(g_snapshot.lanes));
+        std::memset(g_snapshot.lanes, OEM_LANE_NONE, sizeof(g_snapshot.lanes));
     }
     seqlock_end();
 }

--- a/mazda/patches/blmjciaapa/hud/vbs_tx.h
+++ b/mazda/patches/blmjciaapa/hud/vbs_tx.h
@@ -57,9 +57,10 @@ void vbs_tx_next_turn(const char *road_name, uint32_t dir_icon);
 void vbs_tx_distance(int32_t dist_dec, uint8_t dist_unit);
 
 // Recommended-lane array (GAL 1.6 only; the 1.5 path never sends lanes). Exactly
-// 8 Mazda lane bytes, LEFT to RIGHT (0=hidden, 1=unmarked, 22=marked; hud.cpp
-// encodes them). Carried on a SEPARATE OEM method (VBS_NAVI_SetRecommLaneReq) —
-// see vbs_tx.cpp for the emit-side 0 -> 0xFF hidden-slot remap.
+// 8 Mazda cluster GLYPH bytes, LEFT to RIGHT (0=hidden) — hud.cpp encodes the AA
+// lanes to OEM codes and maps each to a cluster glyph, since this path bypasses
+// svcjcinavi. Carried on a SEPARATE OEM method (VBS_NAVI_SetRecommLaneReq) — see
+// vbs_tx.cpp for the emit-side 0 -> kVbsLaneHidden (0xFF) hidden-slot remap.
 void vbs_tx_lanes(const uint8_t *lanes);
 
 #endif // LIBPATCH_BLMJCIAAPA_VBS_TX_H


### PR DESCRIPTION
VBS - fixed to Table A for now, no easy way to find which HUD type is in use