### PR TITLE
Add 'AutoKit' for the Carlinkit dongle to the device list in bt16pair

### DIFF
--- a/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
+++ b/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
@@ -48,7 +48,8 @@ constexpr char const *kDongleDevNames[] = {
     "smartBox",
     "carplay",
     "carlink",
-    "motorolama1"
+    "motorolama1",
+    "AutoKit"
 };
 
 // AapConnectionManager connect-mode values (instance + 0xdc). Offset and


### PR DESCRIPTION
Carlinkit 5.0 2air dongle (AA and CP) is named as AutoKit. Add AutoKit as device name.
<img width="853" height="283" alt="image" src="https://github.com/user-attachments/assets/bbe452f1-3145-43bf-a490-8b9fce4e8846" />
