### PR TITLE
feat(audio): add Android Auto start/end audio-cutoff fix suite

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -194,6 +194,7 @@ case-insensitive.
 | `force_street_name` | `true` / `false` | `false` | Force the Android Auto street name onto the HUD street line even where the OEM blanks it (see the EU note below). |
 | `hud_fold_latin` | `true` / `false` | `true` | Fold HUD-unrenderable precomposed Latin letters in street names to their base forms (see the note below). |
 | `use_protocol_v1_6` | `true` / `false` | `false` | Advertise Android Auto GAL 1.6 so the phone sends the 1.6 navigation protocol (maneuver / lanes / distance) for the HUD. Read by the `aap_service` shim; requires it to be preloaded (see the note below). |
+| `aa_audio_low_latency` | `true` / `false` | `false` | Fix Android Auto guidance-audio clipping at the head, beginning, and tail of prompts — one switch for the whole audio-cutoff fix. Needs **both** the `aap_service` and `blmjciaapa` shims preloaded (see the note below). |
 
 Booleans are lenient — `true`/`1`/`yes`/`on` and `false`/`0`/`no`/`off`
 are all accepted.
@@ -255,10 +256,35 @@ the street, so it is safe to enable everywhere if preferred.
   Lane guidance is part of the 1.6 protocol, so it is sent automatically
   whenever `use_protocol_v1_6 = true` (and never at stock 1.5).
 
+- **`aa_audio_low_latency`** fixes Android Auto **guidance-audio clipping** — one
+  opt-in switch covering all three edges of a spoken prompt. It is `false` by default
+  because it touches the live audio path; off, the unit behaves stock.
+
+  - **Head / start** — AA playback's per-client ALSA start threshold is lowered from the
+    full negotiated buffer to one period, and the guidance pipeline self-activates after a
+    short pre-roll, so dense / back-to-back prompts don't clip their first few
+    milliseconds.
+  - **Beginning / cold open** — one silent `dmix` client is held open inside `jciAAPA`
+    (0 % CPU — it streams nothing, just holds the fd) so the shared `hw:0,0` output device
+    stays warm. Without it the first prompt over a tuner (FM / DAB) pays a multi-second
+    cold open and loses its opening; because a tuner never keeps that device open, the
+    cost otherwise recurs on *every* prompt.
+  - **Tail / end** — the too-short end-of-stream drain wait is extended so the tail plays
+    out instead of being flushed, and the amplifier mix is held until the drain actually
+    finishes (coupled by a cross-process "tail drained" event), so the amp releases exactly
+    when the audio ends rather than after a guessed delay — no chopped last syllable, no
+    dead-air.
+
+  The head/start and tail/end halves live in the `aap_service` shim (`audio.cpp`,
+  `goactive.cpp`, `sem_clockfix.cpp`); the beginning cold-open and amp-hold halves live in
+  `blmjciaapa` (`audio_keepalive.cpp`, `audio_stopdelay.cpp`). So it needs **both** shims
+  preloaded (step 2). Every piece is gated by this one key — there is no separate audio
+  switch.
+
 After editing `libpatch.conf`, restart the affected service(s) —
 `jciAAPA`, `jcinavi` if you patched it, and `aap_service` if you enabled
-`use_protocol_v1_6` — or reboot for the change to take effect. The config is read
-once at library load.
+`use_protocol_v1_6` or `aa_audio_low_latency` — or reboot for the change to take effect.
+The config is read once at library load.
 
 ## Uninstall / disable
 

--- a/mazda/Makefile
+++ b/mazda/Makefile
@@ -91,7 +91,7 @@ COMMON_CXXFLAGS := -std=c++11 \
 # correctly. We pick up libstdc++.so.6 as a DT_NEEDED instead.
 COMMON_LDFLAGS  := --sysroot=$(SYSROOT) -shared \
                    -Wl,--no-undefined \
-                   -lpthread -ldl \
+                   -lpthread -ldl -lrt \
                    $(PKG_LIBS)
 
 # Debug: no optimization, full debug info, no LTO so symbols/inlining are sane.

--- a/mazda/patches/aap_service/audio/audio.cpp
+++ b/mazda/patches/aap_service/audio/audio.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Lower only Android Auto playback's ALSA auto-start threshold. The shared
-// dmix buffer geometry and every non-AA PCM handle remain untouched.
+// Set the ALSA auto-start threshold on Android Auto playback sinks only. The
+// guidance sink starts on a multi-period cushion, the others on one period;
+// the shared dmix geometry and every non-AA PCM handle stay untouched.
 
 #define LOG_TAG "AUDIO"
 #include "../log.h"
@@ -8,12 +9,21 @@
 #include "common/preload.h"
 
 #include <alsa/asoundlib.h>
+#include <alloca.h>
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <dlfcn.h>
 #include <pthread.h>
 
 namespace {
+
+// Guidance sink (androidautoAltAudio, 16 kHz mono) auto-start threshold, in periods.
+// The threshold is how much audio the sink buffers before it starts playing — the cushion that
+// absorbs delivery jitter. One period underruns on the first late frame, so the prompt garbles or
+// drops; four periods (128 ms) is the whole 2048-frame buffer, the ceiling ALSA allows (a start
+// threshold cannot exceed the buffer). The other AA sinks start on one period.
+const snd_pcm_uframes_t kGuidanceStartPeriods = 4;   // 128 ms; buffer ceiling
 
 typedef int (*pcm_open_fn)(snd_pcm_t **, const char *, snd_pcm_stream_t, int);
 typedef int (*pcm_close_fn)(snd_pcm_t *);
@@ -21,17 +31,35 @@ typedef int (*set_start_threshold_fn)(snd_pcm_t *, snd_pcm_sw_params_t *,
                                       snd_pcm_uframes_t);
 typedef int (*get_params_fn)(snd_pcm_t *, snd_pcm_uframes_t *,
                              snd_pcm_uframes_t *);
+typedef size_t (*hw_params_sizeof_fn)(void);
+typedef int (*hw_params_current_fn)(snd_pcm_t *, snd_pcm_hw_params_t *);
+typedef int (*hw_params_get_rate_fn)(const snd_pcm_hw_params_t *, unsigned int *, int *);
 
 pcm_open_fn            g_real_open = nullptr;
 pcm_close_fn           g_real_close = nullptr;
 set_start_threshold_fn g_real_set_start_threshold = nullptr;
 get_params_fn          g_real_get_params = nullptr;
+hw_params_sizeof_fn    g_real_hw_params_sizeof = nullptr;
+hw_params_current_fn   g_real_hw_params_current = nullptr;
+hw_params_get_rate_fn  g_real_hw_params_get_rate = nullptr;
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+// VERBOSE only: the guidance sink's real write path and fill query, used solely by the
+// diagnostic probe below. A release build has no snd_pcm_writei override, so neither is
+// resolved there.
+typedef snd_pcm_sframes_t (*pcm_writei_fn)(snd_pcm_t *, const void *, snd_pcm_uframes_t);
+pcm_writei_fn          g_real_writei = nullptr;
+typedef snd_pcm_sframes_t (*pcm_avail_update_fn)(snd_pcm_t *);
+pcm_avail_update_fn    g_real_avail_update = nullptr;
+#endif
 pthread_once_t         g_resolve_once = PTHREAD_ONCE_INIT;
 bool                   g_enabled = false;
 
 struct TrackedPcm {
     snd_pcm_t *pcm;
     const char *name;
+    snd_pcm_uframes_t buffer_size;   // captured at start_threshold (0 until known)
+    unsigned rate;                   // Hz, captured at start_threshold (0 if unavailable)
+    unsigned writes;                 // guidance writei count since open (head-window throttle)
 };
 
 TrackedPcm g_tracked[8] = {};
@@ -45,6 +73,37 @@ void resolve_real_functions()
         dlsym(RTLD_NEXT, "snd_pcm_sw_params_set_start_threshold"));
     g_real_get_params = reinterpret_cast<get_params_fn>(
         dlsym(RTLD_NEXT, "snd_pcm_get_params"));
+    // Optional sample-rate lookup, used only to print geometry in ms; never affects the threshold.
+    g_real_hw_params_sizeof = reinterpret_cast<hw_params_sizeof_fn>(
+        dlsym(RTLD_NEXT, "snd_pcm_hw_params_sizeof"));
+    g_real_hw_params_current = reinterpret_cast<hw_params_current_fn>(
+        dlsym(RTLD_NEXT, "snd_pcm_hw_params_current"));
+    g_real_hw_params_get_rate = reinterpret_cast<hw_params_get_rate_fn>(
+        dlsym(RTLD_NEXT, "snd_pcm_hw_params_get_rate"));
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+    g_real_writei = reinterpret_cast<pcm_writei_fn>(
+        dlsym(RTLD_NEXT, "snd_pcm_writei"));
+    g_real_avail_update = reinterpret_cast<pcm_avail_update_fn>(
+        dlsym(RTLD_NEXT, "snd_pcm_avail_update"));
+#endif
+}
+
+// Best-effort read of the PCM's negotiated sample rate (Hz), 0 if unavailable. hw params are
+// fully negotiated by the time the OEM sets the start threshold, so current() reflects the real
+// geometry. Pure measurement — never affects the threshold decision.
+unsigned query_rate(snd_pcm_t *pcm)
+{
+    if (!g_real_hw_params_sizeof || !g_real_hw_params_current || !g_real_hw_params_get_rate)
+        return 0;
+    size_t sz = g_real_hw_params_sizeof();
+    if (!sz) return 0;
+    snd_pcm_hw_params_t *hw = static_cast<snd_pcm_hw_params_t *>(alloca(sz));
+    std::memset(hw, 0, sz);
+    if (g_real_hw_params_current(pcm, hw) < 0) return 0;
+    unsigned rate = 0;
+    int dir = 0;
+    if (g_real_hw_params_get_rate(hw, &rate, &dir) < 0) return 0;
+    return rate;
 }
 
 
@@ -67,6 +126,9 @@ void track_pcm(snd_pcm_t *pcm, const char *name)
         if (!g_tracked[i].pcm) {
             g_tracked[i].pcm = pcm;
             g_tracked[i].name = name;
+            g_tracked[i].buffer_size = 0;   // filled in at start_threshold
+            g_tracked[i].rate = 0;
+            g_tracked[i].writes = 0;        // fresh head-window counter per prompt
             pthread_mutex_unlock(&g_tracked_mu);
             LOGD("tracking playback PCM %s handle=%p", name, (void *)pcm);
             return;
@@ -102,6 +164,64 @@ void untrack_pcm(snd_pcm_t *pcm)
     pthread_mutex_unlock(&g_tracked_mu);
 }
 
+// Record the negotiated geometry on the tracked entry so the writei probe can turn ALSA's
+// available-frame count into a fill level in ms. Cheap; runs for every AA sink (release too),
+// but only the guidance probe reads it back.
+void set_tracked_geometry(snd_pcm_t *pcm, snd_pcm_uframes_t buffer_size, unsigned rate)
+{
+    pthread_mutex_lock(&g_tracked_mu);
+    for (size_t i = 0; i < sizeof(g_tracked) / sizeof(g_tracked[0]); ++i) {
+        if (g_tracked[i].pcm == pcm) {
+            g_tracked[i].buffer_size = buffer_size;
+            g_tracked[i].rate = rate;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_tracked_mu);
+}
+
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+// How many writes at the start of each prompt to log in full (the "head" — the window where an
+// onset underrun would garble the voice). ~1 s of audio; xruns are logged beyond it regardless.
+const unsigned kHeadWrites = 24;
+
+// Under the table lock: is this a sink we probe? If so, hand back its short tag, geometry, and the
+// 0-based index of THIS write (post-increments the stored counter). Two sinks are probed:
+//   "gd" androidautoAltAudio      — nav guidance (16 kHz mono); the head-cut / defect-2 sink.
+//   "vr" androidautoMainAudioVR   — voice/assistant/message-readout TTS; the defect-1 (AAVR mute
+//                                   window) sink. Un-instrumented before this diagnostic build, so
+//                                   the readout PCM onset vs the amp SetMute->SetUnMute window was
+//                                   invisible; now its writei#0 timestamp + head amplitude are
+//                                   logged so the clip can be measured directly.
+// The music sink (androidautoMainAudio) and everything untracked => nullptr, so the writei
+// interpose stays a zero-work pass-through there (no per-frame music spam).
+const char *probe_write_slot(snd_pcm_t *pcm, snd_pcm_uframes_t *buf_out,
+                             unsigned *rate_out, unsigned *idx_out)
+{
+    const char *tag = nullptr;
+    pthread_mutex_lock(&g_tracked_mu);
+    for (size_t i = 0; i < sizeof(g_tracked) / sizeof(g_tracked[0]); ++i) {
+        if (g_tracked[i].pcm == pcm) {
+            if (g_tracked[i].name) {
+                if (std::strcmp(g_tracked[i].name, "androidautoAltAudio") == 0)
+                    tag = "gd";
+                else if (std::strcmp(g_tracked[i].name, "androidautoMainAudioVR") == 0)
+                    tag = "vr";
+            }
+            if (tag) {
+                *buf_out   = g_tracked[i].buffer_size;
+                *rate_out  = g_tracked[i].rate;
+                *idx_out   = g_tracked[i].writes++;
+            }
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_tracked_mu);
+    return tag;
+}
+
+#endif
+
 } // namespace
 
 namespace aap_service_audio {
@@ -109,7 +229,9 @@ namespace aap_service_audio {
 void init()
 {
     g_enabled = true;
-    LOGD("AA playback start threshold override active (one negotiated period)");
+    LOGD("AA playback start threshold override active "
+         "(guidance %lu periods, others one period)",
+         (unsigned long)kGuidanceStartPeriods);
 }
 
 } // namespace aap_service_audio
@@ -150,12 +272,28 @@ int snd_pcm_sw_params_set_start_threshold(snd_pcm_t *pcm,
         return g_real_set_start_threshold(pcm, params, threshold);
     }
 
-    const snd_pcm_uframes_t replacement =
-        period_size < threshold ? period_size : threshold;
-    LOGD("%s handle=%p: buffer=%lu period=%lu start_threshold %lu -> %lu",
-         name, (void *)pcm, (unsigned long)buffer_size,
-         (unsigned long)period_size, (unsigned long)threshold,
-         (unsigned long)replacement);
+    // Guidance starts on a few periods (a real cushion below the pre-roll); the others on one.
+    const bool is_guidance = std::strcmp(name, "androidautoAltAudio") == 0;
+    const snd_pcm_uframes_t periods = is_guidance ? kGuidanceStartPeriods : 1;
+    snd_pcm_uframes_t want = period_size * periods;
+    if (want > buffer_size) want = buffer_size;                 // never exceed the ring
+    const snd_pcm_uframes_t replacement = want < threshold ? want : threshold;
+
+    const unsigned rate = query_rate(pcm);   // measurement-only: 0 if unavailable
+    set_tracked_geometry(pcm, buffer_size, rate);   // for the writei fill probe (VERBOSE)
+    if (rate)
+        LOGD("%s handle=%p rate=%uHz: buffer=%lu(%lums) period=%lu(%lums) "
+             "start_threshold %lu -> %lu (%lums, %lu periods)",
+             name, (void *)pcm, rate,
+             (unsigned long)buffer_size, (unsigned long)(buffer_size * 1000 / rate),
+             (unsigned long)period_size, (unsigned long)(period_size * 1000 / rate),
+             (unsigned long)threshold, (unsigned long)replacement,
+             (unsigned long)(replacement * 1000 / rate), (unsigned long)periods);
+    else
+        LOGD("%s handle=%p: buffer=%lu period=%lu start_threshold %lu -> %lu (%lu periods)",
+             name, (void *)pcm, (unsigned long)buffer_size,
+             (unsigned long)period_size, (unsigned long)threshold,
+             (unsigned long)replacement, (unsigned long)periods);
     return g_real_set_start_threshold(pcm, params, replacement);
 }
 
@@ -164,6 +302,94 @@ int snd_pcm_close(snd_pcm_t *pcm)
 {
     pthread_once(&g_resolve_once, resolve_real_functions);
     if (!g_real_close) return -ENOSYS;
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+    // Probed-sink close marker (VERBOSE): bounds the prompt's sink lifetime and reports how many
+    // head writes it took, so the timeline parser can pair open->close per prompt without guessing.
+    // Same two sinks as the writei probe ("gd" guidance / "vr" voice).
+    if (g_enabled) {
+        pthread_mutex_lock(&g_tracked_mu);
+        for (size_t i = 0; i < sizeof(g_tracked) / sizeof(g_tracked[0]); ++i) {
+            if (g_tracked[i].pcm == pcm && g_tracked[i].name) {
+                const char *tag = nullptr;
+                if (std::strcmp(g_tracked[i].name, "androidautoAltAudio") == 0)
+                    tag = "gd";
+                else if (std::strcmp(g_tracked[i].name, "androidautoMainAudioVR") == 0)
+                    tag = "vr";
+                if (tag)
+                    LOGV("%s CLOSE handle=%p writes=%u", tag, (void *)pcm, g_tracked[i].writes);
+                break;
+            }
+        }
+        pthread_mutex_unlock(&g_tracked_mu);
+    }
+#endif
     if (g_enabled) untrack_pcm(pcm);
     return g_real_close(pcm);
 }
+
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+// snd_pcm_writei interpose — VERBOSE only, compiled out of release (release has no writei
+// override, so the media path is untouched). For a probed sink ("gd" guidance / "vr" voice) it
+// logs the ring fill and the write's return code before each head write:
+//   avail = frames free for writing => fill = buffer_size - avail (how full the ring was)
+//   fill trending to 0 across the head window = the sink draining faster than it refills
+//   rc < 0 (e.g. -EPIPE) = an underrun the sink then recovers from
+// The owning AAL playback thread also calls writei, so reading avail_update here is race-free.
+extern "C" PRELOAD_EXPORT
+snd_pcm_sframes_t snd_pcm_writei(snd_pcm_t *pcm, const void *buffer, snd_pcm_uframes_t size)
+{
+    pthread_once(&g_resolve_once, resolve_real_functions);
+    if (!g_real_writei) return -ENOSYS;
+    if (!g_enabled) return g_real_writei(pcm, buffer, size);
+
+    snd_pcm_uframes_t buf = 0;
+    unsigned rate = 0, idx = 0;
+    const char *tag = probe_write_slot(pcm, &buf, &rate, &idx);
+    if (!tag)
+        return g_real_writei(pcm, buffer, size);   // music / untracked: straight through
+
+    const snd_pcm_sframes_t avail = g_real_avail_update ? g_real_avail_update(pcm) : -1;
+
+    // Head-frame amplitude probe: peak and mean-abs of this frame's leading S16 samples, read from
+    // the caller's buffer before the write. Low then rising over the first frames = a silence-led
+    // head; high on frame #0 = an already-clipped head. Integer-only, over the head window only.
+    // Bounded by `size` (one int16 per frame) so it stays in-bounds whether the sink is mono
+    // (gd, exact) or stereo (vr reads the leading half — still a valid onset-amplitude proxy).
+    long pk = -1, mabs = -1;
+    if (idx < kHeadWrites && buffer && size) {
+        const int16_t *s = static_cast<const int16_t *>(buffer);
+        int32_t peak = 0; uint64_t sum_abs = 0;
+        for (snd_pcm_uframes_t i = 0; i < size; ++i) {
+            int32_t v = s[i]; if (v < 0) v = -v;
+            if (v > peak) peak = v;
+            sum_abs += static_cast<uint32_t>(v);
+        }
+        pk   = peak;
+        mabs = static_cast<long>(sum_abs / size);
+    }
+
+    // On the first frame, re-read the rate here: the stream is fully prepared by now, so it reports
+    // the real ALSA-layer rate even when the sw_params-time query returned 0.
+    if (idx == 0) {
+        const unsigned r = query_rate(pcm);
+        LOGV("%s RATE handle=%p alsa_negotiated=%uHz (0=unavailable)", tag, (void *)pcm, r);
+    }
+
+    const snd_pcm_sframes_t rc    = g_real_writei(pcm, buffer, size);
+
+    long fill_fr = -1, fill_ms = -1;
+    if (avail >= 0 && buf > 0) {
+        fill_fr = static_cast<long>(buf) - static_cast<long>(avail);
+        if (fill_fr < 0) fill_fr = 0;
+        fill_ms = fill_fr * 1000L / static_cast<long>(rate ? rate : 16000);
+    }
+    if (rc < 0)
+        LOGW("%s writei #%u req=%lu avail=%ld fill=%ldfr/%ldms pk=%ld mabs=%ld rc=%ld XRUN",
+             tag, idx, (unsigned long)size, (long)avail, fill_fr, fill_ms, pk, mabs, (long)rc);
+    else if (idx < kHeadWrites)
+        LOGV("%s writei #%u req=%lu avail=%ld fill=%ldfr/%ldms pk=%ld mabs=%ld rc=%ld",
+             tag, idx, (unsigned long)size, (long)avail, fill_fr, fill_ms, pk, mabs, (long)rc);
+
+    return rc;
+}
+#endif

--- a/mazda/patches/aap_service/audio/audio.h
+++ b/mazda/patches/aap_service/audio/audio.h
@@ -7,6 +7,10 @@ namespace aap_service_audio {
 
 void init();
 
+// Audio EOS-drain "tail" fix (sem_clockfix.cpp). Call once from the constructor after config load,
+// so the gate is resolved up front, not on the first sem_timedwait.
+void sem_clockfix_init();
+
 } // namespace aap_service_audio
 
 #endif // LIBPATCH_AAP_SERVICE_AUDIO_H

--- a/mazda/patches/aap_service/audio/goactive.cpp
+++ b/mazda/patches/aap_service/audio/goactive.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// goactive.cpp — fix the start ("head") of an Android Auto nav/guidance prompt being clipped
+// when prompts arrive back-to-back.
+//
+// The guidance audio pipeline only starts playing once the head unit sends its "go active"
+// command, which arrives after the phone has already begun streaming. Until then every
+// incoming frame is buffered in the player's small ring. If the pipeline is then activated on
+// just one buffered frame, the ALSA sink underruns before the next frame arrives and the first
+// few milliseconds are lost; when prompts come back-to-back the head unit's go-active is
+// delayed further and more of the head is dropped.
+//
+// We interpose the player's push-buffer entry point (reached for every incoming frame). When a
+// guidance frame is buffered because the pipeline is still inactive, we count it; once a few
+// frames have accumulated we self-activate the pipeline via the player's own AudioActive(), so
+// it starts with a cushion instead of on one frame. The buffered frames (head included) drain
+// into the pipeline on activation, and the head unit's later go-active becomes a harmless no-op.
+//
+// Pure interpose — no memory writes, no detour, so none of aap_service's restart risk. Gated by
+// libpatch.conf `aa_audio_low_latency` (the AA low-latency audio switch; this is its start-side half,
+// paired with the end-side drain fix). Fail-open: a prompt that never reaches the cushion count
+// is still started by the head unit's own go-active, so the worst case is stock timing.
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE          // dladdr() via common/config.h; RTLD_NEXT via common/preload.h
+#endif
+
+#define LOG_TAG "GOACTIVE"
+#include "../log.h"             // LIBPATCH_NAME=aap_service + common/log.h (LOG*)
+#include "common/preload.h"     // PRELOAD_EXPORT, resolve_real_symbol()
+#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency} (opt-in gate)
+
+#include <stdint.h>
+
+namespace {
+
+// Read the player's stream-type field the same way the player does: player -> context
+// sub-object (+0x6c) -> stream-type word (+0x10). Only the guidance/nav stream (0xa02) suffers
+// the back-to-back head clip, so media and the third stream are intentionally left alone.
+const uintptr_t kPlayerCtxOff   = 0x6c;   // player -> context sub-object
+const uintptr_t kStreamTypeOff  = 0x10;   // context sub-object -> stream-type word
+const unsigned  kStreamGuidance = 0xa02;  // the guidance/nav audio stream
+
+// push_buffer's return value when the frame was buffered because the pipeline is inactive.
+const int kRingedRet = -2;
+
+// How many buffered guidance frames to accumulate before self-activating. Activating on the
+// first frame starts the pipeline with ~1 frame buffered, and the ALSA sink (start threshold of
+// one period, see audio.cpp) then underruns on the phone's early trickle — the first few ms drop
+// and garble. Three frames is the smallest cushion that starts cleanly, and it is far below the
+// player's ring capacity so accumulating it never drops the head of the prompt.
+const int kPrerollFloor = 3;
+
+typedef int  (*push_buffer_fn)(void *player, void *a1, void *data, unsigned int len);
+typedef void (*audio_active_fn)(int stream_type);
+
+unsigned read_stream_type(void *player)
+{
+    if (!player) return 0;
+    uintptr_t ctx = *reinterpret_cast<uintptr_t *>(
+        reinterpret_cast<char *>(player) + kPlayerCtxOff);
+    if (!ctx) return 0;
+    return *reinterpret_cast<unsigned *>(ctx + kStreamTypeOff);
+}
+
+} // namespace
+
+extern "C" PRELOAD_EXPORT
+int gst_media_audio_player_push_buffer(void *player, void *a1, void *data, unsigned int len)
+{
+    // Resolve the real OEM push once (RTLD_NEXT skips this interpose; aap_service is the main
+    // exe and libaap_adplayer.so is a global DT_NEEDED, so RTLD_NEXT sees it directly).
+    static void          *h_push = nullptr;
+    static push_buffer_fn real   = reinterpret_cast<push_buffer_fn>(resolve_real_symbol(
+        "gst_media_audio_player_push_buffer", "libaap_adplayer.so",
+        "/usr/lib/libaap_adplayer.so",
+        reinterpret_cast<void *>(&gst_media_audio_player_push_buffer), &h_push));
+    if (!real)
+        return kRingedRet;   // unresolved (shouldn't happen) — mimic the OEM inactive return
+
+    // Opt-in gate: libpatch.conf `aa_audio_low_latency` (default false). Off => pure pass-through.
+    static int enabled = -1;
+    if (enabled < 0) {
+        libpatch_config::load(reinterpret_cast<const void *>(&gst_media_audio_player_push_buffer));
+        enabled = libpatch_config::aa_audio_low_latency() ? 1 : 0;
+    }
+
+    const int ret = real(player, a1, data, len);
+    if (!enabled)
+        return ret;
+
+    // Only the guidance stream (0xa02) suffers the dense-prompt start starvation.
+    if (read_stream_type(player) != kStreamGuidance)
+        return ret;
+
+    // This push runs on the player's single audio worker — the same thread AudioActive runs on —
+    // so no lock is needed and calling AudioActive from here is thread-correct (and idempotent
+    // anyway: a redundant call is a no-op).
+    //   ret == 0  : the frame was accepted => the pipeline is already playing => reset the count
+    //               and re-arm for the next prompt's cold start.
+    //   ret == -2 : the frame was buffered because the pipeline is inactive. Count it; once
+    //               kPrerollFloor frames have accumulated, self-activate so the buffered cushion
+    //               (head frame included) drains into the sink and it starts cleanly.
+    //
+    // `ringed` resets only on ret == 0, so a prompt shorter than the floor that never plays leaves
+    // it non-zero; the effect is bounded (the next start may activate a frame or two early) and
+    // self-heals on the first accepted frame. Real utterances are dozens of frames, so this is not
+    // reachable in practice.
+    //
+    // Fail-open: the head unit always sends its own go-active after focus is granted, so a prompt
+    // that never reaches the floor is still started by that path — worst case is stock timing,
+    // never a hang. No timer involved.
+    static bool armed  = true;
+    static int  ringed = 0;
+    if (ret == 0) {
+        armed  = true;
+        ringed = 0;
+        return ret;
+    }
+    if (ret != kRingedRet || !armed)
+        return ret;
+    if (++ringed < kPrerollFloor)   // accumulate the cushion before activating
+        return ret;
+    armed = false;
+
+    static void           *h_aa = nullptr;
+    static audio_active_fn  aa   = reinterpret_cast<audio_active_fn>(resolve_real_symbol(
+        "AudioActive", "libaap_adplayer.so", "/usr/lib/libaap_adplayer.so",
+        nullptr /* not interposed */, &h_aa));
+    if (aa) {
+        aa(static_cast<int>(kStreamGuidance));
+        LOGD("self-activated guidance pipeline after %d-frame pre-roll "
+             "(dense-prompt start-cutoff fix); go-active race bypassed", kPrerollFloor);
+    }
+    return ret;
+}

--- a/mazda/patches/aap_service/audio/goactive.cpp
+++ b/mazda/patches/aap_service/audio/goactive.cpp
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// goactive.cpp — fix the start ("head") of an Android Auto nav/guidance prompt being clipped
-// when prompts arrive back-to-back.
+// goactive.cpp — start ("head") of an Android Auto nav/guidance prompt underrunning the ALSA
+// sink, which garbles the first fraction of the prompt.
 //
 // The guidance audio pipeline only starts playing once the head unit sends its "go active"
-// command, which arrives after the phone has already begun streaming. Until then every
-// incoming frame is buffered in the player's small ring. If the pipeline is then activated on
-// just one buffered frame, the ALSA sink underruns before the next frame arrives and the first
-// few milliseconds are lost; when prompts come back-to-back the head unit's go-active is
-// delayed further and more of the head is dropped.
+// command, which arrives after the phone has already begun streaming. Until then every incoming
+// frame is buffered in the player's small ring. Waiting for that late go-active is itself lost
+// head, so we self-activate as soon as a minimal cushion of frames has buffered — this ADVANCES
+// the prompt onset versus stock (we start before the head unit tells us to), which is exactly what
+// a nav prompt wants: the voice must not start late.
 //
-// We interpose the player's push-buffer entry point (reached for every incoming frame). When a
-// guidance frame is buffered because the pipeline is still inactive, we count it; once a few
-// frames have accumulated we self-activate the pipeline via the player's own AudioActive(), so
-// it starts with a cushion instead of on one frame. The buffered frames (head included) drain
-// into the pipeline on activation, and the head unit's later go-active becomes a harmless no-op.
+// The cushion here is deliberately the SMALLEST that lets the pipeline come up cleanly — its job
+// is a fast onset, not riding delivery jitter. Making it deeper would only push the voice onset
+// later, which is unacceptable for guidance. The jitter-underrun that garbles some prompts is an
+// ALSA sink-buffer problem and is addressed on the sink side (audio.cpp), where cushion can be
+// added without moving the onset.
 //
 // Pure interpose — no memory writes, no detour, so none of aap_service's restart risk. Gated by
 // libpatch.conf `aa_audio_low_latency` (the AA low-latency audio switch; this is its start-side half,
@@ -31,12 +31,13 @@
 #include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency} (opt-in gate)
 
 #include <stdint.h>
+#include <time.h>              // clock_gettime — measurement-only per-frame arrival probe (VERBOSE)
 
 namespace {
 
 // Read the player's stream-type field the same way the player does: player -> context
 // sub-object (+0x6c) -> stream-type word (+0x10). Only the guidance/nav stream (0xa02) suffers
-// the back-to-back head clip, so media and the third stream are intentionally left alone.
+// the onset underrun, so media and the third stream are intentionally left alone.
 const uintptr_t kPlayerCtxOff   = 0x6c;   // player -> context sub-object
 const uintptr_t kStreamTypeOff  = 0x10;   // context sub-object -> stream-type word
 const unsigned  kStreamGuidance = 0xa02;  // the guidance/nav audio stream
@@ -44,11 +45,13 @@ const unsigned  kStreamGuidance = 0xa02;  // the guidance/nav audio stream
 // push_buffer's return value when the frame was buffered because the pipeline is inactive.
 const int kRingedRet = -2;
 
-// How many buffered guidance frames to accumulate before self-activating. Activating on the
-// first frame starts the pipeline with ~1 frame buffered, and the ALSA sink (start threshold of
-// one period, see audio.cpp) then underruns on the phone's early trickle — the first few ms drop
-// and garble. Three frames is the smallest cushion that starts cleanly, and it is far below the
-// player's ring capacity so accumulating it never drops the head of the prompt.
+// How many buffered guidance frames to accumulate before self-activating. This is a fast-onset
+// knob, NOT a jitter cushion: keep it as small as possible so the voice starts as early as
+// possible. Activating on the very first frame can come up before the pipeline is settled;
+// three frames is the smallest count that reliably brings the pipeline up, and it is far below
+// the player's ring capacity so accumulating it never drops the head of the prompt. Raising it
+// would delay the voice onset — which for a nav prompt is a safety regression — so the fix for
+// jitter garble lives on the ALSA sink side instead (see audio.cpp), not here.
 const int kPrerollFloor = 3;
 
 typedef int  (*push_buffer_fn)(void *player, void *a1, void *data, unsigned int len);
@@ -89,9 +92,28 @@ int gst_media_audio_player_push_buffer(void *player, void *a1, void *data, unsig
     if (!enabled)
         return ret;
 
-    // Only the guidance stream (0xa02) suffers the dense-prompt start starvation.
+    // Only the guidance stream (0xa02) suffers the onset underrun.
     if (read_stream_type(player) != kStreamGuidance)
         return ret;
+
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+    // Measurement-only (compiled out of release): one line per guidance frame so a single capture
+    // reveals the head profile without any behaviour change — ret (-2 buffered / 0 accepted marks
+    // where playback started), len (chunk size => pre-roll depth in bytes/ms), and dt (inter-frame
+    // arrival gap => the delivery jitter that underruns the sink). The tool derives pre-roll ms
+    // and the max early gap from this stream.
+    {
+        static struct timespec probe_prev = { 0, 0 };
+        struct timespec probe_now;
+        clock_gettime(CLOCK_MONOTONIC, &probe_now);
+        long probe_dt = (probe_prev.tv_sec || probe_prev.tv_nsec)
+            ? (probe_now.tv_sec - probe_prev.tv_sec) * 1000L
+              + (probe_now.tv_nsec - probe_prev.tv_nsec) / 1000000L
+            : -1;
+        probe_prev = probe_now;
+        LOGV("gd frame ret=%d len=%u dt=%ldms", ret, len, probe_dt);
+    }
+#endif
 
     // This push runs on the player's single audio worker — the same thread AudioActive runs on —
     // so no lock is needed and calling AudioActive from here is thread-correct (and idempotent
@@ -100,7 +122,8 @@ int gst_media_audio_player_push_buffer(void *player, void *a1, void *data, unsig
     //               and re-arm for the next prompt's cold start.
     //   ret == -2 : the frame was buffered because the pipeline is inactive. Count it; once
     //               kPrerollFloor frames have accumulated, self-activate so the buffered cushion
-    //               (head frame included) drains into the sink and it starts cleanly.
+    //               (head frame included) drains into the sink and it starts cleanly — earlier
+    //               than the head unit's own (late) go-active.
     //
     // `ringed` resets only on ret == 0, so a prompt shorter than the floor that never plays leaves
     // it non-zero; the effect is bounded (the next start may activate a frame or two early) and
@@ -119,7 +142,7 @@ int gst_media_audio_player_push_buffer(void *player, void *a1, void *data, unsig
     }
     if (ret != kRingedRet || !armed)
         return ret;
-    if (++ringed < kPrerollFloor)   // accumulate the cushion before activating
+    if (++ringed < kPrerollFloor)   // accumulate the minimal cushion before activating
         return ret;
     armed = false;
 
@@ -130,7 +153,7 @@ int gst_media_audio_player_push_buffer(void *player, void *a1, void *data, unsig
     if (aa) {
         aa(static_cast<int>(kStreamGuidance));
         LOGD("self-activated guidance pipeline after %d-frame pre-roll "
-             "(dense-prompt start-cutoff fix); go-active race bypassed", kPrerollFloor);
+             "(onset start-cutoff fix); go-active race bypassed", kPrerollFloor);
     }
     return ret;
 }

--- a/mazda/patches/aap_service/audio/sem_clockfix.cpp
+++ b/mazda/patches/aap_service/audio/sem_clockfix.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// sem_clockfix.cpp — fix the end ("tail") of an Android Auto guidance prompt being cut off.
+//
+// When a guidance clip stops, the audio player pushes end-of-stream and waits on a semaphore
+// for the pipeline to drain its buffered tail. That wait has a fixed timeout that is too short:
+// the drain can take ~1.2 s but the wait gives up much sooner, so the buffered tail is flushed
+// and the last part of the sentence is lost.
+//
+// We interpose libc sem_timedwait and, only for that one EOS-drain wait, extend the timeout.
+// The semaphore is posted the moment the drain actually finishes, so the wait returns then —
+// the extension is only a ceiling, never a fixed delay. On success we also post a cross-process
+// token (see common/audio/drain_event.h) so blmjciaapa releases the amplifier mix exactly when the
+// tail is gone.
+//
+// The player's stop path has several timed waits; we must extend ONLY the EOS-drain one and
+// leave the pipeline-stop waits alone. They are told apart by the low bits of the return address
+// (the library is page-aligned, so this offset is stable across loads).
+//
+// Pure interpose — writes no memory, installs no detour, so none of aap_service's restart risk.
+// Pairs with blmjciaapa's audio_stopdelay (holds the amp mix past the drain); the start-side
+// head-clip is handled by goactive and the cold-open (beginning) by audio_keepalive — all under
+// this same switch. Gated by libpatch.conf `aa_audio_low_latency` (default false). Needs -lrt
+// (clock_gettime).
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE          // dladdr() via common/config.h; RTLD_NEXT via common/preload.h
+#endif
+
+#define LOG_TAG "SEMFIX"
+#include "../log.h"             // LIBPATCH_NAME=aap_service + common/log.h (LOG*)
+#include "common/preload.h"     // PRELOAD_EXPORT, resolve_real_symbol()
+#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency} (opt-in gate)
+#include "common/audio/drain_event.h" // drain_event::{open_sem,post} — tell blmjciaapa the tail drained
+
+#include <semaphore.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+
+// Identifies the EOS-drain wait by the low 12 bits of its return address (the library is
+// page-aligned, so this offset is stable across loads). This is the only timed wait we extend;
+// the pipeline-stop waits in the same function return to different offsets and are left alone.
+static const uintptr_t kEosDrainRetPageOff = 0x198;
+static const uintptr_t kPageOffMask        = 0xFFF;
+// Fail-open ceiling. The wait is event-driven — the semaphore is posted the instant the tail
+// finishes draining (~1.2 s), so the wait returns then; this is only a backstop for a
+// pathological never-fires case. We only ever extend a too-short wait, never shorten one, so a
+// longer timeout set by a future firmware is left untouched.
+static const long kEosWaitSec = 3;
+
+extern "C" PRELOAD_EXPORT
+int sem_timedwait(sem_t *sem, const struct timespec *abstime)
+{
+    typedef int (*real_fn)(sem_t *, const struct timespec *);
+    static void   *handle = nullptr;
+    static real_fn real   = reinterpret_cast<real_fn>(resolve_real_symbol(
+        "sem_timedwait", "libpthread.so.0", "/lib/libpthread.so.0",
+        reinterpret_cast<void *>(&sem_timedwait), &handle));
+    if (!real)
+        return -1;   // unresolved (shouldn't happen) — behave like a failed wait
+
+    // Opt-in gate: libpatch.conf `aa_audio_low_latency` (default false). Off => pure pass-through.
+    static int enabled = -1;
+    if (enabled < 0) {
+        libpatch_config::load(reinterpret_cast<const void *>(&sem_timedwait));
+        enabled = libpatch_config::aa_audio_low_latency() ? 1 : 0;
+        if (enabled) {
+            // Line-buffer the player's own stdout/stderr so its log timestamps reflect when
+            // audio events actually happen (it is otherwise block-buffered, which batches the
+            // timeline into clumps). Pure libc; runs once, early.
+            setvbuf(stdout, nullptr, _IOLBF, 0);
+            setvbuf(stderr, nullptr, _IOLBF, 0);
+        }
+    }
+    if (!abstime || !enabled)
+        return real(sem, abstime);
+
+    const uintptr_t ret     = reinterpret_cast<uintptr_t>(__builtin_return_address(0));
+    const uintptr_t ret_off = ret & kPageOffMask;
+
+    struct timespec rt;
+    clock_gettime(CLOCK_REALTIME, &rt);
+    // Remaining time until the caller's deadline, in realtime terms (what sem_timedwait uses).
+    const long rem_ms = (long)(abstime->tv_sec  - rt.tv_sec) * 1000L
+                      + (long)(abstime->tv_nsec - rt.tv_nsec) / 1000000L;
+
+    // Verbose per-call trace: confirm the interpose is bound and show each wait's remaining time
+    // and call-site offset, so the EOS-drain site stays identifiable on-car. Compiled out entirely
+    // unless the shim is built at verbose level (LOG_LEVEL_VERBOSE) — the level gate is the switch,
+    // no manual call counter.
+    LOGV("sem_timedwait HIT: rem=%ldms retoff=0x%03lx abstime={%ld,%09ld} caller=%p",
+         rem_ms, (unsigned long)ret_off,
+         (long)abstime->tv_sec, (long)abstime->tv_nsec, (void *)ret);
+
+    // The EOS-drain wait. Extend its deadline so the pipeline finishes draining and the tail
+    // plays instead of being flushed (only ever extend, never shorten); then, the instant it
+    // returns success, post a cross-process "tail drained" token so blmjciaapa's audio_stopdelay
+    // releases the amp mix exactly then rather than guessing a fixed hold. See common/audio/drain_event.h.
+    if (ret_off == kEosDrainRetPageOff) {
+        // Clear any stale token here, at drain-START — not at the consumer's arm. The stop
+        // reaches this drain before it reaches blmjciaapa's arm, and a short prompt can finish
+        // draining (and post its token) inside that gap; resetting at drain-start clears
+        // leftovers without ever wiping the token this drain is about to post.
+        static int psemid = -1;
+        if (psemid < 0)
+            psemid = drain_event::open_sem();
+        drain_event::reset(psemid);
+
+        const struct timespec *use = abstime;
+        struct timespec fixed;
+        if (rem_ms < kEosWaitSec * 1000L) {
+            fixed.tv_sec  = rt.tv_sec + kEosWaitSec;
+            fixed.tv_nsec = rt.tv_nsec;
+            use = &fixed;
+            LOGD("sem_timedwait: extended EOS-drain wait %ldms -> %lds (audio cutoff fix); caller=%p",
+                 rem_ms, kEosWaitSec, (void *)ret);
+        }
+
+        const int r = real(sem, use);
+
+        // r == 0 => the semaphore was posted => the tail has drained THIS INSTANT. Signal the
+        // amp-hold consumer to un-mix now. r != 0 (ETIMEDOUT at the ceiling / EINTR) => the
+        // drain did not complete, so we post nothing and the consumer falls back to its cap.
+        if (r == 0) {
+            drain_event::post(psemid);
+            LOGD("sem_timedwait: EOS drain complete -> posted drain-done event "
+                 "(amp release, event-driven); caller=%p", (void *)ret);
+        }
+        return r;
+    }
+    return real(sem, abstime);
+}

--- a/mazda/patches/aap_service/audio/sem_clockfix.cpp
+++ b/mazda/patches/aap_service/audio/sem_clockfix.cpp
@@ -24,13 +24,12 @@
 // (clock_gettime).
 
 #ifndef _GNU_SOURCE
-#  define _GNU_SOURCE          // dladdr() via common/config.h; RTLD_NEXT via common/preload.h
+#  define _GNU_SOURCE          // semtimedop via common/audio/drain_event.h; RTLD_NEXT via common/preload.h
 #endif
 
 #define LOG_TAG "SEMFIX"
 #include "../log.h"             // LIBPATCH_NAME=aap_service + common/log.h (LOG*)
 #include "common/preload.h"     // PRELOAD_EXPORT, resolve_real_symbol()
-#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency} (opt-in gate)
 #include "common/audio/drain_event.h" // drain_event::{open_sem,post} — tell blmjciaapa the tail drained
 
 #include <semaphore.h>
@@ -49,6 +48,15 @@ static const uintptr_t kPageOffMask        = 0xFFF;
 // longer timeout set by a future firmware is left untouched.
 static const long kEosWaitSec = 3;
 
+// Set once by sem_clockfix_init() (after config load); default off => pass-through when disabled or
+// before init. Plain (not atomic): the aap_service constructor runs before any OEM audio thread
+// exists, so the write happens-before every reader via thread creation.
+static bool g_enabled = false;
+
+// Producer (drain-done) semaphore, opened once in sem_clockfix_init() so the matched EOS-drain path
+// does no semget. -1 until opened / if the open fails (drain_event::reset/post tolerate -1).
+static int g_psemid = -1;
+
 extern "C" PRELOAD_EXPORT
 int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 {
@@ -60,20 +68,9 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
     if (!real)
         return -1;   // unresolved (shouldn't happen) — behave like a failed wait
 
-    // Opt-in gate: libpatch.conf `aa_audio_low_latency` (default false). Off => pure pass-through.
-    static int enabled = -1;
-    if (enabled < 0) {
-        libpatch_config::load(reinterpret_cast<const void *>(&sem_timedwait));
-        enabled = libpatch_config::aa_audio_low_latency() ? 1 : 0;
-        if (enabled) {
-            // Line-buffer the player's own stdout/stderr so its log timestamps reflect when
-            // audio events actually happen (it is otherwise block-buffered, which batches the
-            // timeline into clumps). Pure libc; runs once, early.
-            setvbuf(stdout, nullptr, _IOLBF, 0);
-            setvbuf(stderr, nullptr, _IOLBF, 0);
-        }
-    }
-    if (!abstime || !enabled)
+    // Gate is resolved in sem_clockfix_init() (constructor time), never here — no config I/O on
+    // the libc-wait path. Off => pass-through.
+    if (!abstime || !g_enabled)
         return real(sem, abstime);
 
     const uintptr_t ret     = reinterpret_cast<uintptr_t>(__builtin_return_address(0));
@@ -102,10 +99,7 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
         // reaches this drain before it reaches blmjciaapa's arm, and a short prompt can finish
         // draining (and post its token) inside that gap; resetting at drain-start clears
         // leftovers without ever wiping the token this drain is about to post.
-        static int psemid = -1;
-        if (psemid < 0)
-            psemid = drain_event::open_sem();
-        drain_event::reset(psemid);
+        drain_event::reset(g_psemid);
 
         const struct timespec *use = abstime;
         struct timespec fixed;
@@ -123,7 +117,7 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
         // amp-hold consumer to un-mix now. r != 0 (ETIMEDOUT at the ceiling / EINTR) => the
         // drain did not complete, so we post nothing and the consumer falls back to its cap.
         if (r == 0) {
-            drain_event::post(psemid);
+            drain_event::post(g_psemid);
             LOGD("sem_timedwait: EOS drain complete -> posted drain-done event "
                  "(amp release, event-driven); caller=%p", (void *)ret);
         }
@@ -131,3 +125,22 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
     }
     return real(sem, abstime);
 }
+
+namespace aap_service_audio {
+
+// Called once from the aap_service constructor, after config load, to enable the EOS-drain
+// extension. Resolving the gate here (not on the first sem_timedwait) keeps config I/O off the
+// libc-wait path, where a fault would take the whole process down.
+void sem_clockfix_init()
+{
+    g_enabled = true;
+    g_psemid  = drain_event::open_sem();   // producer sem up front, off the wait path
+#if LOG_LEVEL <= LOG_LEVEL_VERBOSE
+    // Verbose builds only: line-buffer the player's stdout/stderr so its log timestamps aren't
+    // batched into clumps. Release stdio is untouched.
+    setvbuf(stdout, nullptr, _IOLBF, 0);
+    setvbuf(stderr, nullptr, _IOLBF, 0);
+#endif
+}
+
+} // namespace aap_service_audio

--- a/mazda/patches/aap_service/audio/sem_clockfix.cpp
+++ b/mazda/patches/aap_service/audio/sem_clockfix.cpp
@@ -86,7 +86,7 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
                       + (long)(abstime->tv_nsec - rt.tv_nsec) / 1000000L;
 
     // Verbose per-call trace: confirm the interpose is bound and show each wait's remaining time
-    // and call-site offset, so the EOS-drain site stays identifiable on-car. Compiled out entirely
+    // and call-site offset, so the EOS-drain site stays identifiable in a trace. Compiled out entirely
     // unless the shim is built at verbose level (LOG_LEVEL_VERBOSE) — the level gate is the switch,
     // no manual call counter.
     LOGV("sem_timedwait HIT: rem=%ldms retoff=0x%03lx abstime={%ld,%09ld} caller=%p",

--- a/mazda/patches/aap_service/main.cpp
+++ b/mazda/patches/aap_service/main.cpp
@@ -30,6 +30,7 @@ void aap_service_patch_init()
 
     if (libpatch_config::aa_audio_low_latency()) {
         aap_service_audio::init();
+        aap_service_audio::sem_clockfix_init();
     } else {
         LOGD("aa_audio_low_latency=false -> stock ALSA start threshold; "
              "audio module inert");

--- a/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
@@ -16,8 +16,8 @@
 //     there is no write loop and no recovery logic.
 //   * We run inside jciAAPA (a restart-critical service), so the surface is minimized: one
 //     detached thread does the open once (any error just fails open — no warming, no crash)
-//     then parks in pause() holding the fd. After the open there is no ongoing ALSA activity,
-//     so the steady-state fault surface is ~nil.
+//     and exits — the fd is owned by the process, not the thread, so nothing has to hold it.
+//     After the open there is no ongoing ALSA activity, so the steady-state fault surface is ~nil.
 //
 // Gated by libpatch.conf `aa_audio_low_latency` (default false) — the beginning edge of the
 // same AA audio-cutoff fix as the start/head (goactive) and end/tail (sem_clockfix +
@@ -95,8 +95,10 @@ snd_pcm_t *open_hold_dmix()
 
 void *keepalive_thread(void *)
 {
-    open_hold_dmix();          // open once; on failure, fail open (no warming)
-    for (;;) pause();          // park forever, holding the fd (near-zero fault surface)
+    // Open the dmix client once (blocking — a cold open can take seconds, hence its own thread)
+    // and return. The pcm fd is owned by the process, not this thread, so it stays open with no
+    // thread parked on it. On failure we just fail open.
+    open_hold_dmix();
     return nullptr;
 }
 

--- a/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
@@ -22,8 +22,9 @@
 // Gated by libpatch.conf `aa_audio_low_latency` (default false) — the beginning edge of the
 // same AA audio-cutoff fix as the start/head (goactive) and end/tail (sem_clockfix +
 // audio_stopdelay) halves, all under the one switch. ALSA is reached via dlopen (no build-time
-// libasound dependency). The open blocks (a cold open can take seconds), so it MUST run off the
-// loader/constructor thread.
+// libasound dependency). The open blocks (a cold open can take seconds), so it runs on its own
+// detached thread, spawned by audio_keepalive_init() from lifecycle.cpp's session bracket
+// (alongside touch/hud/play-pause) rather than from a library constructor.
 
 #ifndef _GNU_SOURCE
 #  define _GNU_SOURCE
@@ -31,8 +32,8 @@
 
 #define LOG_TAG "KEEPALIVE"
 #include "../log.h"             // LIBPATCH_NAME=blmjciaapa + common/log.h (LOG*)
-#include "common/preload_guard.h" // preload_read_cmdline / preload_is_launcher_process
-#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency}
+#include "audio_keepalive.h"    // audio_keepalive_init() (this TU defines it)
+#include "common/thread_util.h" // preload_thread_create (bounded stack)
 
 #include <dlfcn.h>
 #include <pthread.h>
@@ -44,6 +45,7 @@ struct snd_pcm_t;   // opaque
 enum { kStreamPlayback = 0, kFormatS16LE = 2, kAccessRwInterleaved = 3 };
 typedef int (*pcm_open_fn)(snd_pcm_t **, const char *, int, int);
 typedef int (*pcm_set_params_fn)(snd_pcm_t *, int, int, unsigned, unsigned, int, unsigned);
+typedef int (*pcm_close_fn)(snd_pcm_t *);
 
 // Open one dmix client and return its (intentionally leaked) handle, or nullptr on any
 // failure (fail open — the unit just behaves as stock, no warming). Opened ONCE.
@@ -57,6 +59,9 @@ snd_pcm_t *open_hold_dmix()
     }
     pcm_open_fn       pcm_open       = reinterpret_cast<pcm_open_fn>(dlsym(lib, "snd_pcm_open"));
     pcm_set_params_fn pcm_set_params = reinterpret_cast<pcm_set_params_fn>(dlsym(lib, "snd_pcm_set_params"));
+    // Only needed on the set_params failure path below; not a hard requirement
+    // (the success path never closes), so its absence doesn't block warming.
+    pcm_close_fn      pcm_close      = reinterpret_cast<pcm_close_fn>(dlsym(lib, "snd_pcm_close"));
     if (!pcm_open || !pcm_set_params) {
         LOGE("keepalive: dlsym snd_pcm_{open,set_params} incomplete");
         return nullptr;
@@ -78,7 +83,11 @@ snd_pcm_t *open_hold_dmix()
                          /*latency_us*/ 500000);
     if (err < 0) {
         LOGE("keepalive: snd_pcm_set_params failed: %d", err);
-        return nullptr;   // leak the handle; we're failing open anyway
+        // Close the just-opened client so a failed attach neither leaks the
+        // handle nor holds a slot on the shared dmix IPC. (The success path
+        // below deliberately never closes — holding it open IS the mechanism.)
+        if (pcm_close) pcm_close(pcm);
+        return nullptr;
     }
     LOGD("keepalive: holding plug:dmix_48000 open -> hw:0,0 warm (0%% CPU, no streaming); pcm=%p", pcm);
     return pcm;
@@ -91,31 +100,28 @@ void *keepalive_thread(void *)
     return nullptr;
 }
 
-// Runs at dlopen of libpatch-blmjciaapa.so (jciAAPA start). Spawns the holder on a detached
-// thread so the (potentially multi-second) cold open never blocks jciAAPA startup.
-__attribute__((constructor))
-void audio_keepalive_init()
+} // namespace  (open_hold_dmix + keepalive_thread stay TU-private)
+
+// Start the dmix warmer, once per process. Called from lifecycle.cpp's
+// aap_create_session bracket (gated on aa_audio_low_latency) — the same place
+// touch/hud/play-pause are wired, so the launcher-process detection and the
+// config gate live there instead of a duplicated constructor guard here. The
+// open can block for seconds (a cold open), so it runs on a bounded, detached
+// thread (common/thread_util.h): the 256 KiB stack bound avoids glibc's default
+// multi-MB per-thread reservation on the memory-tight CMU, and the detach keeps
+// the never-joined fire-and-forget semantics. Idempotent — repeat session edges
+// are no-ops.
+void audio_keepalive_init(void)
 {
-    // This constructor is inherited by EVERY process that gets our LD_PRELOAD, including the
-    // short-lived helper children the system spawns roughly once a second. Only run in the real
-    // service host (jciAAPA); otherwise we'd parse config, spawn a thread, dlopen libasound and
-    // race a dmix open in every throwaway child. Same guard main.cpp uses.
-    char cmdline[256];
-    preload_read_cmdline(cmdline, sizeof cmdline);
-    if (!preload_is_launcher_process(cmdline))
-        return;
+    static bool started = false;
+    if (started) return;
+    started = true;
 
-    libpatch_config::load(reinterpret_cast<const void *>(&audio_keepalive_init));
-    if (!libpatch_config::aa_audio_low_latency())
-        return;
-
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     pthread_t t;
-    if (pthread_create(&t, &attr, keepalive_thread, nullptr) != 0)
-        LOGE("keepalive: pthread_create failed — no route keepalive");
-    pthread_attr_destroy(&attr);
+    int rc = preload_thread_create(&t, keepalive_thread, nullptr);
+    if (rc != 0) {
+        LOGE("keepalive: thread create failed (%d) — no route keepalive", rc);
+        return;
+    }
+    pthread_detach(t);
 }
-
-} // namespace

--- a/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_keepalive.cpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// audio_keepalive.cpp — keep the shared output device warm so the FIRST AA audio over a tuner
+// isn't lost to a cold open (the "beginning cut off").
+//
+// The AA guidance sink ends at the shared dmix device -> hw:0,0. With a tuner (FM/DAB, analog,
+// never a dmix client) in the background that device is closed, so the first AA prompt pays a
+// cold open + power-up of several seconds, during which the phone's audio is dropped. A dmix
+// client that is simply HELD OPEN keeps the shared slave running (it free-runs from first open
+// to last close), so every later AA open is a fast secondary attach.
+//
+// Design points:
+//   * Open once, never close, never reopen. A reopen can collide with the first instance's
+//     not-yet-released shared IPC, so we never do it.
+//   * No writes. The slave free-runs once opened; an idle open fd holds it warm at ~0% CPU, so
+//     there is no write loop and no recovery logic.
+//   * We run inside jciAAPA (a restart-critical service), so the surface is minimized: one
+//     detached thread does the open once (any error just fails open — no warming, no crash)
+//     then parks in pause() holding the fd. After the open there is no ongoing ALSA activity,
+//     so the steady-state fault surface is ~nil.
+//
+// Gated by libpatch.conf `aa_audio_low_latency` (default false) — the beginning edge of the
+// same AA audio-cutoff fix as the start/head (goactive) and end/tail (sem_clockfix +
+// audio_stopdelay) halves, all under the one switch. ALSA is reached via dlopen (no build-time
+// libasound dependency). The open blocks (a cold open can take seconds), so it MUST run off the
+// loader/constructor thread.
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#define LOG_TAG "KEEPALIVE"
+#include "../log.h"             // LIBPATCH_NAME=blmjciaapa + common/log.h (LOG*)
+#include "common/preload_guard.h" // preload_read_cmdline / preload_is_launcher_process
+#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency}
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <unistd.h>
+
+namespace {
+
+struct snd_pcm_t;   // opaque
+enum { kStreamPlayback = 0, kFormatS16LE = 2, kAccessRwInterleaved = 3 };
+typedef int (*pcm_open_fn)(snd_pcm_t **, const char *, int, int);
+typedef int (*pcm_set_params_fn)(snd_pcm_t *, int, int, unsigned, unsigned, int, unsigned);
+
+// Open one dmix client and return its (intentionally leaked) handle, or nullptr on any
+// failure (fail open — the unit just behaves as stock, no warming). Opened ONCE.
+snd_pcm_t *open_hold_dmix()
+{
+    void *lib = dlopen("libasound.so.2", RTLD_NOW | RTLD_GLOBAL);
+    if (!lib) lib = dlopen("/usr/lib/libasound.so.2", RTLD_NOW | RTLD_GLOBAL);
+    if (!lib) {
+        LOGE("keepalive: dlopen libasound.so.2 failed: %s", dlerror() ? dlerror() : "?");
+        return nullptr;
+    }
+    pcm_open_fn       pcm_open       = reinterpret_cast<pcm_open_fn>(dlsym(lib, "snd_pcm_open"));
+    pcm_set_params_fn pcm_set_params = reinterpret_cast<pcm_set_params_fn>(dlsym(lib, "snd_pcm_set_params"));
+    if (!pcm_open || !pcm_set_params) {
+        LOGE("keepalive: dlsym snd_pcm_{open,set_params} incomplete");
+        return nullptr;
+    }
+
+    // `plug:` adapts our S16/48k/2ch to the dmix slave; the dmix instance is shared by IPC key
+    // and uid, so (running as root) we join the same instance the guidance sink attaches to.
+    snd_pcm_t *pcm = nullptr;
+    int err = pcm_open(&pcm, "plug:dmix_48000", kStreamPlayback, 0);
+    if (err < 0 || !pcm) {
+        LOGE("keepalive: snd_pcm_open(plug:dmix_48000) failed: %d", err);
+        return nullptr;
+    }
+    // set_params prepares the stream, which starts the shared hw:0,0 slave (what stays warm).
+    // We never write and never start our own client; it stays prepared while the slave
+    // free-runs, holding the device open at ~0% CPU.
+    err = pcm_set_params(pcm, kFormatS16LE, kAccessRwInterleaved,
+                         /*channels*/ 2, /*rate*/ 48000, /*soft_resample*/ 1,
+                         /*latency_us*/ 500000);
+    if (err < 0) {
+        LOGE("keepalive: snd_pcm_set_params failed: %d", err);
+        return nullptr;   // leak the handle; we're failing open anyway
+    }
+    LOGD("keepalive: holding plug:dmix_48000 open -> hw:0,0 warm (0%% CPU, no streaming); pcm=%p", pcm);
+    return pcm;
+}
+
+void *keepalive_thread(void *)
+{
+    open_hold_dmix();          // open once; on failure, fail open (no warming)
+    for (;;) pause();          // park forever, holding the fd (near-zero fault surface)
+    return nullptr;
+}
+
+// Runs at dlopen of libpatch-blmjciaapa.so (jciAAPA start). Spawns the holder on a detached
+// thread so the (potentially multi-second) cold open never blocks jciAAPA startup.
+__attribute__((constructor))
+void audio_keepalive_init()
+{
+    // This constructor is inherited by EVERY process that gets our LD_PRELOAD, including the
+    // short-lived helper children the system spawns roughly once a second. Only run in the real
+    // service host (jciAAPA); otherwise we'd parse config, spawn a thread, dlopen libasound and
+    // race a dmix open in every throwaway child. Same guard main.cpp uses.
+    char cmdline[256];
+    preload_read_cmdline(cmdline, sizeof cmdline);
+    if (!preload_is_launcher_process(cmdline))
+        return;
+
+    libpatch_config::load(reinterpret_cast<const void *>(&audio_keepalive_init));
+    if (!libpatch_config::aa_audio_low_latency())
+        return;
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_t t;
+    if (pthread_create(&t, &attr, keepalive_thread, nullptr) != 0)
+        LOGE("keepalive: pthread_create failed — no route keepalive");
+    pthread_attr_destroy(&attr);
+}
+
+} // namespace

--- a/mazda/patches/blmjciaapa/audio/audio_keepalive.h
+++ b/mazda/patches/blmjciaapa/audio/audio_keepalive.h
@@ -5,10 +5,11 @@
 #ifndef LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_KEEPALIVE_H
 #define LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_KEEPALIVE_H
 
-// Defined in audio_keepalive.cpp. Starts (once per process) a detached holder
-// thread that opens the shared dmix client and holds it open forever, so the
-// first AA prompt over a tuner doesn't pay the multi-second cold open of the
-// shared hw:0,0 slave. Idempotent — safe to call on every session bring-up.
+// Defined in audio_keepalive.cpp. Starts (once per process) a short detached
+// thread that opens the shared dmix client and exits; the fd is process-owned,
+// so the client stays open forever and the first AA prompt over a tuner doesn't
+// pay the multi-second cold open of the shared hw:0,0 slave. Idempotent — safe
+// to call on every session bring-up.
 // Called from aap_create_session (lifecycle.cpp), gated on aa_audio_low_latency:
 // the launcher-process detection and the config gate live there, alongside
 // touch/hud/play-pause, instead of a duplicated constructor guard in the module.

--- a/mazda/patches/blmjciaapa/audio/audio_keepalive.h
+++ b/mazda/patches/blmjciaapa/audio/audio_keepalive.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Session-lifecycle entry point for the Android Auto audio cold-open keepalive.
+
+#ifndef LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_KEEPALIVE_H
+#define LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_KEEPALIVE_H
+
+// Defined in audio_keepalive.cpp. Starts (once per process) a detached holder
+// thread that opens the shared dmix client and holds it open forever, so the
+// first AA prompt over a tuner doesn't pay the multi-second cold open of the
+// shared hw:0,0 slave. Idempotent — safe to call on every session bring-up.
+// Called from aap_create_session (lifecycle.cpp), gated on aa_audio_low_latency:
+// the launcher-process detection and the config gate live there, alongside
+// touch/hud/play-pause, instead of a duplicated constructor guard in the module.
+void audio_keepalive_init(void);
+
+#endif // LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_KEEPALIVE_H

--- a/mazda/patches/blmjciaapa/audio/audio_preopen.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_preopen.cpp
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// audio_preopen.cpp — open the amp's guidance (NAVI) mix channel early so the head of an
+// Android Auto guidance prompt is not clipped.
+//
+// The amp opens its NAVI channel only once guidance audio focus is requested, and the OEM
+// requests it at stream start — a couple hundred ms after it has already granted the guidance
+// duck, with the request -> amp-NAVI-up round-trip adding more. So the channel opens well after
+// the first PCM sample has already reached the ALSA sink; that head is written while the amp is
+// still routed to media, so it is lost acoustically, downstream of snd_pcm_writei — not in the
+// digital sink.
+//
+// Fix: issue the OEM's own guidance focus request earlier — at the moment the OEM grants the
+// guidance duck, which happens during focus negotiation, well before its own (late) stream-start
+// request. It is idempotent with that later request (a duplicate grant is benign), adds no onset
+// latency, injects no audio, and only ducks media slightly early. The amp NAVI channel then opens
+// at or before PCM onset, not after.
+//
+// Trigger: the OEM's grant runs inside AudioManager::SendReplyRequestFocus, and it grants the
+// guidance duck on exactly one argument pair — stream type 0xa01, request 0x802. We reproduce that
+// exact gate and act only then, so the pre-open fires precisely when (and only when) the OEM's own
+// duck-grant path runs — never on the mic-only listening reply or any other request.
+//
+// Mechanism: an entry detour on SendReplyRequestFocus. The OEM's callers reach it by a direct,
+// link-time-bound branch inside blmjciaapa.so, so symbol interposition cannot catch it; a one-time
+// code patch is required. The detour observes the arguments, fires the early focus request when the
+// gate matches, and then falls straight through into the unmodified OEM function, which runs
+// normally. The live AudioManager is the detour's own `this` (the object the OEM is about to use),
+// so no separate lookup and no cached pointer.
+//
+// Objective validation (the pre-open provably "took hold"): the install verifies the OEM prologue
+// byte-for-byte before patching and ABORTs on any mismatch (never a silent no-op), then reads the
+// patch back. A status file at STATUS_PATH is written on install and refreshed on every grant, so
+// `cat` on the unit confirms the detour is installed and shows live counters (grants seen / fires /
+// last result) independent of build or log level.
+//
+// Gated under the libpatch.conf key `aa_audio_low_latency` (shared with the tail-side hold).
+
+#define LOG_TAG "PREOPEN"
+#include "../log.h"
+
+#include "common/preload.h"
+#include "common/config.h"
+#include "../oem/blmjciaapa.h"   // AudioManager_SendReplyRequestFocus_addr()
+
+#include <cstdint>
+#include <cstdio>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+namespace {
+
+// --- OEM ABI: AUDIO_AMSERVICE_requestAudioFocus ----------------------------
+// Exported by libjciamclient.so; requests guidance audio focus.
+struct AMResult {
+    int   code;
+    char *msg1;
+    char *msg2;
+};
+typedef void (*requestAudioFocus_fn)(void *serviceDbus, unsigned sessionId,
+                                     int flags, AMResult *result);
+
+// --- OEM gate reproduced from AudioManager::SendReplyRequestFocus -----------
+// The OEM does nothing unless the stream type is 0xa01, then grants the guidance
+// duck only for request 0x802 (the 0x800/0x801 requests are other focus states).
+// We fire the pre-open on exactly that pair and nothing else.
+const unsigned kTypeGuidance = 0xa01;   // AAP_StreamType
+const unsigned kReqDuckGrant = 0x802;   // AAP_StreamRequest -> guidance duck
+
+// --- AudioManager instance field offsets ------------------------------------
+const size_t kOffServiceDbus = 0x04;    // service D-Bus handle
+const size_t kOffSessionId1  = 0x24;    // guidance mix session id (-> amp NAVI)
+
+// Dedup window: collapses a rapid re-grant of the same duck into one request
+// (idempotent anyway; this just avoids a redundant call). NOT an added delay.
+// CLOCK_MONOTONIC nanoseconds overflow a 32-bit long after ~2.1 s of uptime on
+// this ILP32 ARM target, so all time math MUST be int64_t.
+const int64_t kDedupNs = 250LL * 1000000LL;   // 250 ms
+
+// Objective-validation status file. Written on install, refreshed on each grant.
+// `cat` it on the unit to confirm the detour is live and see the counters.
+const char STATUS_PATH[] = "/tmp/aa_preopen.status";
+
+// --- ARM detour encodings (verified against the OEM prologue) ----------------
+// SendReplyRequestFocus starts:
+//     a6f40:  e92d4800  push {fp, lr}
+//     a6f44:  e28db004  add  fp, sp, #4
+//     a6f48:  e24dd020  sub  sp, sp, #32   <- resume point (entry + 8)
+// We overwrite the first two words (8 bytes) with an absolute branch to our
+// stub and relocate those two words into the stub's tail. Neither is
+// PC-relative, so relocating them is safe.
+const uint32_t kOrigWord0 = 0xe92d4800;   // push {fp, lr}
+const uint32_t kOrigWord1 = 0xe28db004;   // add  fp, sp, #4
+const uint32_t kLdrPcMinus4 = 0xe51ff004;  // ldr pc, [pc, #-4]  (branch via next word)
+
+// --- lazily resolved handles / config --------------------------------------
+requestAudioFocus_fn g_req_focus      = nullptr;
+void                *g_amclient_handle = nullptr;
+
+pthread_mutex_t g_lock         = PTHREAD_MUTEX_INITIALIZER;
+int64_t         g_last_fire_ns = 0;      // CLOCK_MONOTONIC of last fire
+__thread int    g_in_preopen   = 0;      // re-entrancy guard
+
+// Validation counters (updated under g_lock).
+unsigned g_stat_seen  = 0;   // SendReplyRequestFocus duck-grants observed
+unsigned g_stat_fired = 0;   // pre-opens actually issued
+int      g_stat_code  = -1;  // last requestAudioFocus result code
+void    *g_detour_addr = nullptr;   // patched OEM address (for the status file)
+
+int64_t now_ns()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+// Rewrite the status file. Cheap and infrequent (once per prompt at most).
+// Best-effort: a failed write never affects the audio path.
+void write_status(bool installed)
+{
+    char buf[256];
+    int n = snprintf(buf, sizeof buf,
+        "detour=%s addr=%p prologue=%08x,%08x\n"
+        "seen=%u fired=%u last_code=%d\n",
+        installed ? "installed" : "not-installed",
+        g_detour_addr, kOrigWord0, kOrigWord1,
+        g_stat_seen, g_stat_fired, g_stat_code);
+    if (n <= 0)
+        return;
+    int fd = open(STATUS_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+        return;
+    ssize_t w = write(fd, buf, (size_t)n);
+    (void)w;
+    close(fd);
+}
+
+// Page-align + mprotect helper (same idiom as aap_service/navi/navi.cpp).
+bool set_prot(uintptr_t addr, size_t len, int prot)
+{
+    const uintptr_t ps   = (uintptr_t)sysconf(_SC_PAGESIZE);
+    const uintptr_t page = addr & ~(ps - 1);
+    return mprotect(reinterpret_cast<void *>(page), (addr + len) - page, prot) == 0;
+}
+
+// Fire the OEM's own guidance focus request early, so the amp opens its NAVI
+// channel by PCM onset. `am` is the live AudioManager (the detour's `this`).
+void fire_preopen(void *am)
+{
+    if (g_in_preopen)
+        return;                     // don't re-enter from requestAudioFocus's own path
+
+    // Dedup: collapse a rapid re-grant of the same duck into one request.
+    int64_t t = now_ns();
+    pthread_mutex_lock(&g_lock);
+    int64_t since = t - g_last_fire_ns;
+    if (g_last_fire_ns != 0 && since < kDedupNs) {
+        pthread_mutex_unlock(&g_lock);
+        LOGV("skip: within dedup window (%lld ms)", (long long)(since / 1000000LL));
+        return;
+    }
+    g_last_fire_ns = t;
+    pthread_mutex_unlock(&g_lock);
+
+    if (!am) { LOGD("skip: null AudioManager"); return; }
+
+    void    *serviceDbus = *reinterpret_cast<void **>(
+                               reinterpret_cast<char *>(am) + kOffServiceDbus);
+    unsigned session     = *reinterpret_cast<unsigned *>(
+                               reinterpret_cast<char *>(am) + kOffSessionId1);
+    if (!serviceDbus || session == 0) {
+        LOGD("skip: serviceDbus=%p session=0x%x not ready", serviceDbus, session);
+        return;
+    }
+
+    if (!g_req_focus) {
+        g_req_focus = reinterpret_cast<requestAudioFocus_fn>(resolve_real_symbol(
+            "AUDIO_AMSERVICE_requestAudioFocus", "libjciamclient.so",
+            "/jci/lib/libjciamclient.so", nullptr, &g_amclient_handle));
+    }
+    if (!g_req_focus) { LOGW("skip: requestAudioFocus unresolved"); return; }
+
+    // The OEM's own audio-focus request, fired early.
+    AMResult r;
+    r.code = 0; r.msg1 = nullptr; r.msg2 = nullptr;
+    g_in_preopen = 1;
+    g_req_focus(serviceDbus, session, 0, &r);
+    g_in_preopen = 0;
+
+    pthread_mutex_lock(&g_lock);
+    g_stat_fired++;
+    g_stat_code = r.code;
+    pthread_mutex_unlock(&g_lock);
+
+    LOGV("pre-opened amp NAVI: requestAudioFocus(dbus=%p sess=0x%x) code=%d",
+         serviceDbus, session, r.code);
+}
+
+// The detour's callee. Runs at SendReplyRequestFocus entry with the OEM's own
+// arguments (this, AAP_StreamType, AAP_StreamRequest), fires the pre-open on the
+// exact duck-grant gate, then returns so the original OEM function runs unchanged.
+// Only its address is used (the stub calls it via blx), so plain linkage is fine.
+void preopen_hook(void *self, unsigned type, unsigned req)
+{
+    if (type != kTypeGuidance || req != kReqDuckGrant)
+        return;
+    pthread_mutex_lock(&g_lock);
+    g_stat_seen++;
+    pthread_mutex_unlock(&g_lock);
+    fire_preopen(self);
+    write_status(true);
+}
+
+// Runtime-built trampoline stub (9 words). Entered from the patched OEM prologue
+// in ARM state; saves the arg/scratch registers, calls preopen_hook, restores
+// them, runs the relocated original prologue, and jumps back to entry+8.
+//
+//   [0] e92d500f  push {r0-r3, r12, lr}   ; preserve args + scratch + lr
+//   [1] e59f3014  ldr  r3, [pc, #0x14]    ; r3 = [8] = &preopen_hook
+//   [2] e12fff33  blx  r3                 ; preopen_hook(this, type, req)
+//   [3] e8bd500f  pop  {r0-r3, r12, lr}   ; restore exactly as the OEM saw them
+//   [4] <orig w0> push {fp, lr}           ; relocated OEM prologue word 0
+//   [5] <orig w1> add  fp, sp, #4         ; relocated OEM prologue word 1
+//   [6] e51ff004  ldr  pc, [pc, #-4]      ; branch to [7]
+//   [7] <resume>  entry + 8               ; a6f48 at runtime
+//   [8] <&hook>   &preopen_hook           ; (thumb bit preserved -> blx interworks)
+uint32_t *build_stub(uintptr_t resume)
+{
+    const uintptr_t ps = (uintptr_t)sysconf(_SC_PAGESIZE);
+    void *mem = mmap(nullptr, ps, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mem == MAP_FAILED) {
+        LOGC("install: ABORT - mmap for detour stub failed");
+        return nullptr;
+    }
+    uint32_t *s = reinterpret_cast<uint32_t *>(mem);
+    s[0] = 0xe92d500f;
+    s[1] = 0xe59f3014;
+    s[2] = 0xe12fff33;
+    s[3] = 0xe8bd500f;
+    s[4] = kOrigWord0;
+    s[5] = kOrigWord1;
+    s[6] = kLdrPcMinus4;
+    s[7] = (uint32_t)resume;
+    s[8] = (uint32_t)reinterpret_cast<uintptr_t>(&preopen_hook);
+
+    if (mprotect(mem, ps, PROT_READ | PROT_EXEC) != 0) {
+        LOGC("install: ABORT - mprotect RX on detour stub failed");
+        return nullptr;
+    }
+    __builtin___clear_cache(reinterpret_cast<char *>(s),
+                            reinterpret_cast<char *>(s + 9));
+    return s;
+}
+
+// Install the entry detour on AudioManager::SendReplyRequestFocus. Once per
+// process; re-calls are no-ops. Verifies the OEM prologue byte-for-byte and
+// ABORTs (never silently no-ops) on any mismatch or missing library.
+void install_detour()
+{
+    static bool done = false;
+    if (done)
+        return;
+
+    void *target = AudioManager_SendReplyRequestFocus_addr();
+    if (!target) {
+        // blmjciaapa.so not mapped yet / wrong PID. Not fatal — retry on the
+        // next session bring-up; the caller invokes us again then.
+        LOGD("install: SendReplyRequestFocus unresolved (blmjciaapa.so not mapped?) — will retry");
+        return;
+    }
+
+    volatile uint32_t *code = reinterpret_cast<volatile uint32_t *>(target);
+    if (code[0] == kLdrPcMinus4) {          // already patched (defensive)
+        done = true;
+        LOGD("install: detour already present at %p", target);
+        return;
+    }
+    if (code[0] != kOrigWord0 || code[1] != kOrigWord1) {
+        // Wrong offset / firmware drift. Refuse to patch and stay inert — a
+        // wrong write here would corrupt the OEM. Loud, and survives release.
+        LOGC("install: ABORT - prologue mismatch at %p: got %08x,%08x expected %08x,%08x",
+             target, code[0], code[1], kOrigWord0, kOrigWord1);
+        done = true;                        // don't hammer a bad target every session
+        return;
+    }
+
+    uintptr_t t = reinterpret_cast<uintptr_t>(target);
+    uint32_t *stub = build_stub(t + 8);
+    if (!stub)                              // build_stub already logged the abort
+        return;
+
+    if (!set_prot(t, 8, PROT_READ | PROT_WRITE | PROT_EXEC)) {
+        LOGC("install: ABORT - mprotect RW on %p failed", target);
+        return;
+    }
+    code[0] = kLdrPcMinus4;                 // ldr pc, [pc, #-4]
+    code[1] = (uint32_t)reinterpret_cast<uintptr_t>(stub);
+    set_prot(t, 8, PROT_READ | PROT_EXEC);
+    __builtin___clear_cache(reinterpret_cast<char *>(t),
+                            reinterpret_cast<char *>(t + 8));
+
+    // Read back and confirm the patch physically landed — objective proof the
+    // approach took hold, independent of whether it ever fires.
+    if (code[0] != kLdrPcMinus4 ||
+        code[1] != (uint32_t)reinterpret_cast<uintptr_t>(stub)) {
+        LOGC("install: ABORT - read-back mismatch at %p (%08x,%08x)",
+             target, code[0], code[1]);
+        done = true;
+        return;
+    }
+
+    done = true;
+    g_detour_addr = target;
+    write_status(true);
+    LOGD("install: detour LIVE on SendReplyRequestFocus @%p -> stub %p (verified); "
+         "status at %s", target, (void *)stub, STATUS_PATH);
+}
+
+} // namespace
+
+// --- lifecycle entry -------------------------------------------------------
+void audio_preopen_post_aap_create_session(void)
+{
+    install_detour();
+}

--- a/mazda/patches/blmjciaapa/audio/audio_preopen.h
+++ b/mazda/patches/blmjciaapa/audio/audio_preopen.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Session-lifecycle entry point for the Android Auto guidance head pre-open.
+
+#ifndef LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_PREOPEN_H
+#define LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_PREOPEN_H
+
+// Defined in audio_preopen.cpp. Installs (once per process) an entry detour on
+// the OEM AudioManager::SendReplyRequestFocus so that the amplifier's guidance
+// (NAVI) mix is opened early — at the OEM's own duck-grant, ahead of its later
+// stream-start focus request — which is what keeps the head of a guidance
+// prompt from being clipped. Safe to call on every session bring-up: the detour
+// is a permanent code patch and re-calls are no-ops. Called from
+// aap_create_session (lifecycle.cpp) once blmjciaapa.so is confirmed mapped;
+// the constructor is too early (the OEM library isn't loaded yet).
+void audio_preopen_post_aap_create_session(void);
+
+#endif // LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_PREOPEN_H

--- a/mazda/patches/blmjciaapa/audio/audio_stopdelay.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_stopdelay.cpp
@@ -35,16 +35,17 @@
 // detour, so none of jciAAPA's restart risk. Needs -lrt (timer_settime) and -lpthread.
 
 #ifndef _GNU_SOURCE
-#  define _GNU_SOURCE          // RTLD_NEXT via common/preload.h; dladdr via common/config.h;
+#  define _GNU_SOURCE          // RTLD_NEXT via common/preload.h;
 #endif                         // semtimedop via common/audio/drain_event.h
 
 #define LOG_TAG "STOPDELAY"
 #include "../log.h"             // LIBPATCH_NAME=blmjciaapa + common/log.h (LOG*)
 #include "common/preload.h"     // PRELOAD_EXPORT, resolve_real_symbol()
-#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency}
+#include "common/thread_util.h" // preload_thread_create (bounded-stack helper thread)
 #include "common/audio/drain_event.h" // drain_event::{open_sem,wait} — the drain-done event
                                 // (the producer owns reset(), at drain-start; see the note below)
 
+#include <atomic>
 #include <errno.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -89,7 +90,11 @@ static bool            g_pending = false;   // a fresh re-arm job is waiting
 static unsigned        g_gen     = 0;       // bumped per arm; supersedes an in-flight helper job
 static timer_t         g_job_timerid;       // the OEM stop timer of the current job
 static int             g_semid   = -1;      // the drain-done SysV semaphore
-static bool            g_event_ready = false;
+// Written by audio_stopdelay_init() on the session thread, read by the interpose on OEM worker
+// threads that already exist — atomic to avoid a data race. Off => pass-through; a stale read is
+// always safe (stock pass-through, or the fixed hold).
+static std::atomic<bool> g_event_ready{false};
+static std::atomic<bool> g_enabled{false};
 
 // Helper thread: for each arm, wait for the drain-done token then make the OEM stop timer fire
 // ~immediately, so the OEM's own handler un-mixes the amp right when the tail drained.
@@ -136,32 +141,6 @@ static void *drain_helper(void *)
     }
 }
 
-// Bring up the semaphore + helper thread once. Called under g_lock from the first matched arm.
-// Returns true if the event path is usable; false => the caller uses the fixed-hold fallback.
-static bool ensure_event_machinery_locked()
-{
-    static bool tried = false;
-    if (tried)
-        return g_event_ready;
-    tried = true;
-
-    g_semid = drain_event::open_sem();
-    if (g_semid < 0)
-        return false;   // reset()/wait() already logged
-
-    pthread_t th;
-    if (pthread_create(&th, nullptr, &drain_helper, nullptr) != 0) {
-        LOGE("audio_stopdelay: pthread_create(drain_helper) failed: errno=%d -> fixed-hold "
-             "fallback", errno);
-        return false;
-    }
-    pthread_detach(th);
-    g_event_ready = true;
-    LOGD("audio_stopdelay: event-driven amp release armed (drain-done -> un-mix; %lds fail-safe)",
-         kCapSec);
-    return true;
-}
-
 extern "C" PRELOAD_EXPORT
 int timer_settime(timer_t timerid, int flags,
                   const struct itimerspec *new_value, struct itimerspec *old_value)
@@ -177,11 +156,9 @@ int timer_settime(timer_t timerid, int flags,
     if (!real)
         return -1;   // unresolved (shouldn't happen) — behave like a failed arm
 
-    static int enabled = -1;
-    if (enabled < 0) {
-        libpatch_config::load(reinterpret_cast<const void *>(&timer_settime));
-        enabled = libpatch_config::aa_audio_low_latency() ? 1 : 0;
-    }
+    // Gate is resolved in audio_stopdelay_init(), never here — no config I/O on the libc timer
+    // path. Off => pass-through.
+    const bool enabled = g_enabled.load(std::memory_order_acquire);
     if (!enabled || !new_value)
         return real(timerid, flags, new_value, old_value);
 
@@ -193,19 +170,20 @@ int timer_settime(timer_t timerid, int flags,
         new_value->it_value.tv_sec  == 0 &&
         new_value->it_value.tv_nsec == kGuidanceStopNs)
     {
-        pthread_mutex_lock(&g_lock);
-        const bool ready = ensure_event_machinery_locked();
+        // Machinery is brought up once in audio_stopdelay_init(); here we only read the flag.
+        const bool ready = g_event_ready.load(std::memory_order_acquire);
         if (ready) {
             // Do NOT reset the semaphore here. The producer (sem_clockfix) clears stale tokens
             // at drain-start, which always precedes this arm; a short prompt can finish draining
             // (and post its token) before we get here, and resetting at the arm would wipe the
             // token we're about to wait for. Just hand the job to the helper and wait.
+            pthread_mutex_lock(&g_lock);
             g_job_timerid = timerid;
             ++g_gen;
             g_pending = true;
             pthread_cond_signal(&g_cv);
+            pthread_mutex_unlock(&g_lock);
         }
-        pthread_mutex_unlock(&g_lock);
 
         struct itimerspec ext = *new_value;
         if (ready) {
@@ -228,4 +206,37 @@ int timer_settime(timer_t timerid, int flags,
         return real(timerid, flags, &ext, old_value);
     }
     return real(timerid, flags, new_value, old_value);
+}
+
+// Bring up the drain-done semaphore + persistent helper thread, once. Called from lifecycle.cpp's
+// session bracket after config load, so the gate is resolved up front (not on the first
+// timer_settime) and the matched arm is a bare flag check. On bring-up failure g_event_ready stays
+// false and the interpose falls back to the fixed hold.
+void audio_stopdelay_init(void)
+{
+    static bool started = false;
+    if (started)
+        return;
+    started = true;
+
+    g_enabled.store(true, std::memory_order_release);
+
+    // g_real_timer_settime is resolved (and published) by the interpose on its first call; the
+    // helper picks it up through the g_lock handoff, so there is nothing to resolve here.
+    g_semid = drain_event::open_sem();
+    if (g_semid < 0) {
+        LOGE("audio_stopdelay: drain-done semaphore unavailable -> fixed-hold fallback");
+        return;                       // g_event_ready stays false
+    }
+
+    pthread_t th;
+    if (preload_thread_create(&th, &drain_helper, nullptr) != 0) {   // bounded stack
+        LOGE("audio_stopdelay: preload_thread_create(drain_helper) failed: errno=%d -> "
+             "fixed-hold fallback", errno);
+        return;
+    }
+    pthread_detach(th);
+    g_event_ready.store(true, std::memory_order_release);
+    LOGD("audio_stopdelay: event-driven amp release armed (drain-done -> un-mix; %lds fail-safe)",
+         kCapSec);
 }

--- a/mazda/patches/blmjciaapa/audio/audio_stopdelay.cpp
+++ b/mazda/patches/blmjciaapa/audio/audio_stopdelay.cpp
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// audio_stopdelay.cpp — hold the amplifier's AA mix until the audio tail has drained, then
+// release it the instant the tail is gone (fixes the end of a guidance sentence being cut).
+//
+// After a guidance/media stop, the AudioManager arms a short one-shot timer; when it expires it
+// abandons audio focus and the amplifier un-mixes AA back to the previous source (e.g. FM). But
+// the audio tail can take anywhere from ~0.2 s (warm) to ~2.6 s (a cold first prompt) to drain,
+// so a fixed short hold un-mixes before the tail finishes and chops the clip's end at the
+// amplifier, not in the pipeline.
+//
+// A fixed hold can't win: too short cuts the cold case, too long taxes every warm prompt with
+// dead-air before the music returns. So we use the drain-done moment as an EVENT:
+//   * aap_service (sem_clockfix.cpp) posts a "tail drained" token the instant its EOS-drain
+//     wait completes (common/audio/drain_event.h, a SysV semaphore).
+//   * Here, on the stop-timer arm, we set that OEM timer to a long fail-safe cap (so it can't
+//     un-mix early on its own), hand it to a persistent helper thread, and the helper — as soon
+//     as the token arrives — re-arms the same OEM timer to fire immediately. The OEM's own
+//     handler then un-mixes right after the tail drained:
+//       warm -> un-mix ~at audio-end (no dead-air); cold -> un-mix at ~2.6 s (no cut);
+//       nothing posts -> the fail-safe cap fires (= the old worst case, never worse).
+//
+// Cancellation is free: a new stream cancels the OEM timer and clears its own armed flag.
+// Because the helper re-arms the raw timer (never through the OEM arm path, so it never touches
+// that flag), a re-arm that races a cancel just makes the OEM handler a no-op. The helper also
+// drops any job a newer arm superseded, so it never fires a stale timer. No lock against the OEM
+// cancel path — the OEM state machine already serializes it.
+//
+// Fallback: if the event machinery can't come up (semget or pthread_create fails), degrade to a
+// fixed 1.5 s hold, which covers the common warm drain — never worse than the version this
+// replaces.
+//
+// Gated by libpatch.conf `aa_audio_low_latency` (same switch as the aap_service side; the two
+// are complementary halves of the end-cutoff fix). Pure libc interpose: no memory writes, no
+// detour, so none of jciAAPA's restart risk. Needs -lrt (timer_settime) and -lpthread.
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE          // RTLD_NEXT via common/preload.h; dladdr via common/config.h;
+#endif                         // semtimedop via common/audio/drain_event.h
+
+#define LOG_TAG "STOPDELAY"
+#include "../log.h"             // LIBPATCH_NAME=blmjciaapa + common/log.h (LOG*)
+#include "common/preload.h"     // PRELOAD_EXPORT, resolve_real_symbol()
+#include "common/config.h"      // libpatch_config::{load,aa_audio_low_latency}
+#include "common/audio/drain_event.h" // drain_event::{open_sem,wait} — the drain-done event
+                                // (the producer owns reset(), at drain-start; see the note below)
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+// Identifies the guidance/media stop-timer arm by the low 12 bits of its return address (the
+// library is page-aligned, so this offset is stable across loads). This is the only
+// timer_settime call we act on; every other timer passes through untouched.
+static const uintptr_t kStopTimerRetPageOff = 0xf28;
+static const uintptr_t kPageOffMask         = 0xFFF;
+// The stop delay we act on (200 ms, one-shot). The voice-recognition 500 ms delay and every
+// other value are left alone.
+static const long kGuidanceStopNs = 200000000L;
+
+// Event-driven amp release:
+//   kCapSec   — fail-safe: the longest the amp is ever held if no drain-done token arrives
+//               (matches the aap_service EOS-wait ceiling). = the old worst case, never worse.
+//   kFireNs   — how soon the helper makes the OEM timer expire after the token (must be > 0;
+//               a zero it_value would DISARM the timer instead of firing it).
+//   kWaitCapSec — helper's own wait timeout, just past kCapSec so it always unblocks and loops.
+static const long kCapSec     = 3;
+static const long kFireNs     = 1000000L;   // 1 ms
+static const long kWaitCapSec = kCapSec + 1;
+
+// Fallback fixed hold, used ONLY if the event machinery can't come up: 1.5 s covers the warm
+// drain (0.2-1.7 s), the common case. Same behaviour as before this file went event-driven.
+static const long kHeldStopSec = 1;
+static const long kHeldStopNs  = 500000000L;
+
+typedef int (*timer_settime_fn)(timer_t, int,
+                                const struct itimerspec *, struct itimerspec *);
+
+// The real librt timer_settime, resolved once in the interpose and shared with the helper so
+// the helper's re-arm chains straight through (never back into our shim).
+static timer_settime_fn g_real_timer_settime = nullptr;
+
+// Hand-off from the interpose (OEM worker thread) to the single persistent helper thread.
+static pthread_mutex_t g_lock    = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_cv      = PTHREAD_COND_INITIALIZER;
+static bool            g_pending = false;   // a fresh re-arm job is waiting
+static unsigned        g_gen     = 0;       // bumped per arm; supersedes an in-flight helper job
+static timer_t         g_job_timerid;       // the OEM stop timer of the current job
+static int             g_semid   = -1;      // the drain-done SysV semaphore
+static bool            g_event_ready = false;
+
+// Helper thread: for each arm, wait for the drain-done token then make the OEM stop timer fire
+// ~immediately, so the OEM's own handler un-mixes the amp right when the tail drained.
+static void *drain_helper(void *)
+{
+    for (;;) {
+        // Take the next job.
+        pthread_mutex_lock(&g_lock);
+        while (!g_pending)
+            pthread_cond_wait(&g_cv, &g_lock);
+        timer_t  t       = g_job_timerid;
+        unsigned my_gen  = g_gen;
+        g_pending        = false;
+        pthread_mutex_unlock(&g_lock);
+
+        // Block until aap_service reports the tail drained (or the fail-safe elapses).
+        const int got = drain_event::wait(g_semid, kWaitCapSec);
+
+        // If a newer arm superseded this job while we waited, drop it: don't fire a stale
+        // timerid. The newest arm's own helper iteration + the OEM 3 s cap cover it. (We
+        // deliberately do NOT re-post the consumed token — falling back to the cap is safer
+        // than risking an early un-mix from an out-of-order token.)
+        pthread_mutex_lock(&g_lock);
+        const bool superseded = (g_gen != my_gen);
+        pthread_mutex_unlock(&g_lock);
+        if (superseded)
+            continue;
+
+        if (got == 0 && g_real_timer_settime) {
+            // Drain done -> make the OEM stop timer fire now, so the OEM's own handler un-mixes
+            // the amp. If a cancel already disarmed it, this just makes that handler a no-op
+            // (see the file header). flags=0 => relative.
+            struct itimerspec now;
+            memset(&now, 0, sizeof(now));
+            now.it_value.tv_nsec = kFireNs;
+            g_real_timer_settime(t, 0, &now, nullptr);
+
+            LOGD("drain-done event -> released amp hold (re-armed OEM stop timer to %ldms; "
+                 "event-driven, no dead-air)", kFireNs / 1000000L);
+        } else if (got != 0) {
+            LOGW("no drain-done event within %lds -> OEM stop timer fired at the fail-safe "
+                 "cap (= old worst case)", kCapSec);
+        }
+    }
+}
+
+// Bring up the semaphore + helper thread once. Called under g_lock from the first matched arm.
+// Returns true if the event path is usable; false => the caller uses the fixed-hold fallback.
+static bool ensure_event_machinery_locked()
+{
+    static bool tried = false;
+    if (tried)
+        return g_event_ready;
+    tried = true;
+
+    g_semid = drain_event::open_sem();
+    if (g_semid < 0)
+        return false;   // reset()/wait() already logged
+
+    pthread_t th;
+    if (pthread_create(&th, nullptr, &drain_helper, nullptr) != 0) {
+        LOGE("audio_stopdelay: pthread_create(drain_helper) failed: errno=%d -> fixed-hold "
+             "fallback", errno);
+        return false;
+    }
+    pthread_detach(th);
+    g_event_ready = true;
+    LOGD("audio_stopdelay: event-driven amp release armed (drain-done -> un-mix; %lds fail-safe)",
+         kCapSec);
+    return true;
+}
+
+extern "C" PRELOAD_EXPORT
+int timer_settime(timer_t timerid, int flags,
+                  const struct itimerspec *new_value, struct itimerspec *old_value)
+{
+    static timer_settime_fn real = nullptr;
+    if (!real) {
+        static void *handle = nullptr;
+        real = reinterpret_cast<timer_settime_fn>(resolve_real_symbol(
+            "timer_settime", "librt.so.1", "/lib/librt.so.1",
+            reinterpret_cast<void *>(&timer_settime), &handle));
+        g_real_timer_settime = real;
+    }
+    if (!real)
+        return -1;   // unresolved (shouldn't happen) — behave like a failed arm
+
+    static int enabled = -1;
+    if (enabled < 0) {
+        libpatch_config::load(reinterpret_cast<const void *>(&timer_settime));
+        enabled = libpatch_config::aa_audio_low_latency() ? 1 : 0;
+    }
+    if (!enabled || !new_value)
+        return real(timerid, flags, new_value, old_value);
+
+    const uintptr_t ret_off =
+        reinterpret_cast<uintptr_t>(__builtin_return_address(0)) & kPageOffMask;
+
+    // Only the guidance/media stop-timer arm: unique call site + the 200 ms one-shot.
+    if (ret_off == kStopTimerRetPageOff &&
+        new_value->it_value.tv_sec  == 0 &&
+        new_value->it_value.tv_nsec == kGuidanceStopNs)
+    {
+        pthread_mutex_lock(&g_lock);
+        const bool ready = ensure_event_machinery_locked();
+        if (ready) {
+            // Do NOT reset the semaphore here. The producer (sem_clockfix) clears stale tokens
+            // at drain-start, which always precedes this arm; a short prompt can finish draining
+            // (and post its token) before we get here, and resetting at the arm would wipe the
+            // token we're about to wait for. Just hand the job to the helper and wait.
+            g_job_timerid = timerid;
+            ++g_gen;
+            g_pending = true;
+            pthread_cond_signal(&g_cv);
+        }
+        pthread_mutex_unlock(&g_lock);
+
+        struct itimerspec ext = *new_value;
+        if (ready) {
+            // Arm to the fail-safe cap; the helper re-arms to ~1 ms on the drain-done event.
+            ext.it_value.tv_sec  = kCapSec;
+            ext.it_value.tv_nsec = 0;
+        } else {
+            // Event machinery unavailable — degrade to the fixed hold (warm-drain coverage).
+            ext.it_value.tv_sec  = kHeldStopSec;
+            ext.it_value.tv_nsec = kHeldStopNs;
+        }
+
+        if (ready)
+            LOGD("timer_settime: AA stop-delay armed to %lds fail-safe cap; amp un-mixes on "
+                 "the drain-done event (end-cutoff fix, event-driven)", kCapSec);
+        else
+            LOGW("timer_settime: AA stop-delay stretched 200ms -> %ld.%03lds fixed hold "
+                 "(event machinery down; end-cutoff fix, fallback)",
+                 kHeldStopSec, kHeldStopNs / 1000000L);
+        return real(timerid, flags, &ext, old_value);
+    }
+    return real(timerid, flags, new_value, old_value);
+}

--- a/mazda/patches/blmjciaapa/audio/audio_stopdelay.h
+++ b/mazda/patches/blmjciaapa/audio/audio_stopdelay.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Session-lifecycle entry point for the Android Auto audio END-cutoff amp hold.
+
+#ifndef LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_STOPDELAY_H
+#define LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_STOPDELAY_H
+
+// Defined in audio_stopdelay.cpp. Brings up (once per process) the drain-done SysV semaphore and
+// the persistent helper thread that releases the amplifier's AA mix the instant the audio tail
+// drains. Idempotent — safe to call on every session bring-up. Called from aap_create_session
+// (lifecycle.cpp), gated on aa_audio_low_latency, so the switch is resolved up front (not on the
+// first timer_settime) and the interpose's hot path is a bare flag check.
+void audio_stopdelay_init(void);
+
+#endif // LIBPATCH_BLMJCIAAPA_AUDIO_AUDIO_STOPDELAY_H

--- a/mazda/patches/blmjciaapa/lifecycle.cpp
+++ b/mazda/patches/blmjciaapa/lifecycle.cpp
@@ -22,6 +22,7 @@
 #include "common/config.h"
 #include "audio/audio_keepalive.h"
 #include "audio/audio_preopen.h"
+#include "audio/audio_stopdelay.h"
 #include "hud/hud.h"
 #include "bt16pair/bt16pair.h"
 #include "monitor/navi_monitor.h"
@@ -270,6 +271,12 @@ int aap_create_session(const char *cfg, void *unknown_r1,
             LOGD("aap_create_session: starting audio cold-open keepalive");
             audio_keepalive_init();
             LOGD("audio cold-open keepalive hook completed");
+
+            // End-cutoff amp hold: bring up the drain-done event + helper thread up front (same
+            // low-latency key), so the timer_settime interpose's gate is resolved here, not lazily.
+            LOGD("aap_create_session: arming audio end-cutoff amp hold");
+            audio_stopdelay_init();
+            LOGD("audio end-cutoff amp hold armed");
         } else {
             LOGD("aap_create_session: aa_audio_low_latency disabled by config — "
                   "skipping audio head pre-open + cold-open keepalive");

--- a/mazda/patches/blmjciaapa/lifecycle.cpp
+++ b/mazda/patches/blmjciaapa/lifecycle.cpp
@@ -20,6 +20,8 @@
 #include "log.h"
 #include "lifecycle.h"
 #include "common/config.h"
+#include "audio/audio_keepalive.h"
+#include "audio/audio_preopen.h"
 #include "hud/hud.h"
 #include "bt16pair/bt16pair.h"
 #include "monitor/navi_monitor.h"
@@ -245,6 +247,32 @@ int aap_create_session(const char *cfg, void *unknown_r1,
         } else {
             LOGD("aap_create_session: mute_pauses_phone disabled by config — "
                   "skipping play/pause watcher");
+        }
+
+        // AA guidance head pre-open: install the once-per-process entry detour
+        // on AudioManager::SendReplyRequestFocus so the amp's NAVI mix opens at
+        // the OEM's own duck-grant (ahead of its late stream-start focus
+        // request), keeping the head of a guidance prompt from being clipped.
+        // The install is idempotent, so running it on the same session edge as
+        // the other post-create hooks is safe; blmjciaapa.so is confirmed
+        // mapped by this point (the constructor is too early). Gated on the
+        // shared low-latency key.
+        if (libpatch_config::aa_audio_low_latency()) {
+            LOGD("aap_create_session: installing audio head pre-open detour");
+            audio_preopen_post_aap_create_session();
+            LOGD("audio head pre-open hook completed");
+
+            // Cold-open keepalive: hold the shared dmix client open so the first
+            // guidance prompt over a tuner doesn't pay the multi-second cold open
+            // of the hw:0,0 slave. Once-per-process (idempotent); the holder does
+            // the blocking open on its own thread, so this call doesn't stall
+            // session bring-up. Same low-latency key.
+            LOGD("aap_create_session: starting audio cold-open keepalive");
+            audio_keepalive_init();
+            LOGD("audio cold-open keepalive hook completed");
+        } else {
+            LOGD("aap_create_session: aa_audio_low_latency disabled by config — "
+                  "skipping audio head pre-open + cold-open keepalive");
         }
 
 #if defined(DEBUG) && BLMJCIAAPA_ENABLE_NAVI_MONITOR

--- a/mazda/patches/blmjciaapa/oem/blmjciaapa.cpp
+++ b/mazda/patches/blmjciaapa/oem/blmjciaapa.cpp
@@ -43,6 +43,8 @@ constexpr uintptr_t AudioManager_IsAAMediaInPlaying = 0x000ac3f8;
 constexpr uintptr_t RaceAap_SendTouchInput        = 0x0008e3a8;
 //   _ZN7RaceAap12SendKeyInputEP12AAP_KeyEvent
 constexpr uintptr_t RaceAap_SendKeyInput          = 0x0008e534;
+//   _ZN12AudioManager21SendReplyRequestFocusE14AAP_StreamType17AAP_StreamRequest
+constexpr uintptr_t AudioManager_SendReplyRequestFocus = 0x000a6f40;
 //   _ZN20AapConnectionManager21NotifyBtPairingResultE12true_false_t
 constexpr uintptr_t AapConnectionManager_NotifyBtPairingResult = 0x0007c820;
 //   _ZN20AapConnectionManager18ActivateAapSessionEv
@@ -178,6 +180,14 @@ BLM_FIELD_PTR(char, AapConnectionManager_dev_name,
               off::AapConnectionManager_DevName)
 BLM_FIELD(int, AapConnectionManager_connect_mode,
           off::AapConnectionManager_ConnectMode, -1)
+
+// Address (not a forward) of AudioManager::SendReplyRequestFocus, for the
+// audio head pre-open's entry detour. Same anchor-and-offset resolution as
+// the thunks; nullptr until blmjciaapa.so is mapped.
+void *AudioManager_SendReplyRequestFocus_addr(void)
+{
+	return blm_addr(off::AudioManager_SendReplyRequestFocus);
+}
 
 		  
 // AapConnectionManager instance accessor. GetInstance() may return

--- a/mazda/patches/blmjciaapa/oem/blmjciaapa.h
+++ b/mazda/patches/blmjciaapa/oem/blmjciaapa.h
@@ -97,6 +97,14 @@ int   AudioManager_IsAAMediaInPlaying(void *self);
 int   RaceAap_SendTouchInput(void *self, AAP_TouchEvent *evt);
 int   RaceAap_SendKeyInput(void *self, AAP_KeyEvent *evt);
 
+// Runtime address of AudioManager::SendReplyRequestFocus inside the mapped
+// blmjciaapa.so — the OEM method that grants the guidance audio-focus reply.
+// Unlike the thunks above this returns the ADDRESS (the caller installs an
+// entry detour on it), not a callable forward. nullptr if blmjciaapa.so isn't
+// mapped (wrong PID) or the anchor isn't resolvable yet. Used by the audio
+// head pre-open (audio_preopen.cpp).
+void *AudioManager_SendReplyRequestFocus_addr(void);
+
 // AapConnectionManager access, used by the wireless GAL-1.6 BT-pairing
 // bypass (bt16pair/). The AapConnectionManager is a subobject of the
 // AapProc singleton at AapProc+0x98 (= AapProc::GetAapConnectionManager,

--- a/mazda/patches/common/audio/drain_event.h
+++ b/mazda/patches/common/audio/drain_event.h
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// common/audio/drain_event.h — cross-process "the AA audio tail has finished draining"
+// event, shared by the two halves of the audio END-cutoff fix:
+//
+//   PRODUCER  aap_service / sem_clockfix.cpp   — posts one token the instant the
+//             EOS-drain wait returns success, i.e. the exact moment the buffered
+//             tail has played out.
+//   CONSUMER  blmjciaapa / audio_stopdelay.cpp — waits on that token to release the
+//             amp mix (re-arm the OEM stop timer) precisely when the tail is gone,
+//             instead of guessing a fixed hold duration.
+//
+// The two live in DIFFERENT processes, so the event is a System V counting semaphore
+// keyed by a fixed IPC key. SysV (not a POSIX named semaphore) on purpose: the platform
+// already relies on SysV IPC for ALSA dmix, so it is known-good here, and it needs no
+// /dev/shm. Counting semantics give us lossless edge delivery — a token posted before
+// the consumer waits is still there when it does.
+//
+// Header-only, matching the common/ convention (preload.h / config.h). Requires
+// _GNU_SOURCE to be defined before inclusion (for semtimedop, declared under
+// __USE_GNU in <sys/sem.h>) — every including TU defines it at the top, as they do
+// for dladdr()/RTLD_NEXT.
+
+#ifndef LIBPATCH_COMMON_AUDIO_DRAIN_EVENT_H
+#define LIBPATCH_COMMON_AUDIO_DRAIN_EVENT_H
+
+#include "common/log.h"
+
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <time.h>
+
+namespace drain_event {
+
+// Fixed IPC key shared by producer and consumer. "amdr" = AudioManager DRain.
+// Far from the ALSA dmix ipc_key (10000 = 0x2710); no other SysV sem user on the
+// unit is known to collide.
+static const key_t kKey = 0x616D6472;
+
+// glibc no longer defines `union semun`; POSIX leaves it to the caller. We use our
+// own named union (never clashes with a system definition). Its first member is an
+// int, so passing it by value to the variadic semctl() for SETVAL is layout-correct.
+union semun_t {
+    int                 val;
+    struct semid_ds    *buf;
+    unsigned short     *array;
+};
+
+// Open (creating if absent) the shared 1-slot semaphore. Both processes call this
+// with IPC_CREAT; whoever runs first creates it, the other attaches. 0666 so it works
+// even if the two services run as different users. Returns the semid, or -1 on error.
+inline int open_sem()
+{
+    int id = semget(kKey, 1, IPC_CREAT | 0666);
+    if (id < 0) {
+        LOGE("drain_event: semget(0x%lx) failed: errno=%d", (unsigned long)kKey, errno);
+    }
+    return id;
+}
+
+// PRODUCER: signal that one drain completed (V / +1). Best-effort — a failure (e.g.
+// the value saturating at SEMVMX because the consumer wasn't clearing) is logged and
+// ignored; the consumer's fail-safe cap still bounds the worst case.
+inline void post(int id)
+{
+    if (id < 0) return;
+    struct sembuf op;
+    op.sem_num = 0;
+    op.sem_op  = 1;
+    op.sem_flg = 0;
+    if (semop(id, &op, 1) != 0) {
+        LOGW("drain_event: post failed: errno=%d", errno);
+    }
+}
+
+// PRODUCER: clear any stale tokens so the consumer's next wait() blocks for a FRESH drain.
+// Call this at drain-START (in the producer, just before beginning the EOS-drain wait) — NOT
+// at the consumer's arm. The stop reaches aap_service's drain before it reaches blmjciaapa's
+// arm, so a short prompt can finish draining and post its token before the consumer even
+// arms; resetting on the producer at drain-start clears leftovers without ever eating the
+// current drain's own token, whichever side wins the arm-vs-drain race.
+inline void reset(int id)
+{
+    if (id < 0) return;
+    union semun_t su;
+    su.val = 0;
+    if (semctl(id, 0, SETVAL, su) != 0) {
+        LOGW("drain_event: reset failed: errno=%d", errno);
+    }
+}
+
+// CONSUMER: wait up to timeout_sec for one drain-done token (P / -1). EINTR is
+// retried. Returns 0 if a token arrived, -1 on timeout or error (caller then relies
+// on its fail-safe cap).
+inline int wait(int id, long timeout_sec)
+{
+    if (id < 0) return -1;
+    struct sembuf op;
+    op.sem_num = 0;
+    op.sem_op  = -1;
+    op.sem_flg = 0;
+    struct timespec to;
+    to.tv_sec  = timeout_sec;
+    to.tv_nsec = 0;
+    int r;
+    do {
+        r = semtimedop(id, &op, 1, &to);
+    } while (r != 0 && errno == EINTR);
+    return r == 0 ? 0 : -1;
+}
+
+} // namespace drain_event
+
+#endif // LIBPATCH_COMMON_AUDIO_DRAIN_EVENT_H

--- a/mazda/patches/common/config.h
+++ b/mazda/patches/common/config.h
@@ -27,9 +27,17 @@
 //                                     1.6 navigation protocol (maneuver / lanes / distance)
 //                                     instead of the 1.5 turn events; read by aap_service
 //                                     (default false = stock 1.5)
-//   aa_audio_low_latency = true|false lower Android Auto playback's ALSA start threshold
-//                                     from the full buffer to one negotiated period;
-//                                     read by aap_service (default false)
+//   aa_audio_low_latency = true|false Android Auto low-latency audio: the AA audio-cutoff
+//                                     fix, all three edges of a prompt under one switch.
+//                                     Start/head — lower AA playback's ALSA start threshold
+//                                     to one period (audio.cpp) and self-activate the guidance
+//                                     pipeline after a short pre-roll (goactive.cpp).
+//                                     Beginning — hold one dmix client open in jciAAPA so the
+//                                     shared hw:0,0 stays warm and the first AA prompt over a
+//                                     tuner isn't lost to the cold dmix open (audio_keepalive.cpp).
+//                                     End/tail — extend the too-short EOS-drain wait
+//                                     (sem_clockfix.cpp) and hold the amp mix until the drain
+//                                     finishes (audio_stopdelay.cpp). Read by both libs (default false)
 //   mute_pauses_phone = true|false    on a user mute, send Android Auto a media PAUSE (and a
 //                                     media PLAY on unmute) so the phone stops streaming while
 //                                     muted instead of only silencing the amp (default true)

--- a/resources/libpatch.conf
+++ b/resources/libpatch.conf
@@ -117,10 +117,19 @@ force_street_name = false
 # Default: false
 use_protocol_v1_6 = true
 
-# Lower Android Auto playback's per-client ALSA start threshold from the full
-# negotiated buffer to one negotiated period. With the stock 6144-frame buffer
-# and 1536-frame period at 48 kHz, playback may begin after about 32 ms of
-# queued audio instead of waiting for about 128 ms. This does not change the
-# shared dmix buffer or period geometry and does not affect non-AA PCM handles.
+# Android Auto low-latency audio — the AA audio-cutoff fix, all three edges of a prompt
+# under one switch.
+# Start/head: lower AA playback's per-client ALSA start threshold from the full
+# negotiated buffer to one period (about 32 ms of queued audio vs about 128 ms at
+# 48 kHz; AA PCMs only — the shared dmix geometry and non-AA handles are untouched),
+# and self-activate the guidance pipeline after a short pre-roll so dense/back-to-back
+# prompts don't clip their first few ms.
+# Beginning: hold one dmix client open in jciAAPA (0% CPU — it streams nothing, just holds
+# the fd) so the shared hw:0,0 stays warm and the first AA prompt over a tuner isn't lost to
+# the cold dmix open (audio_keepalive).
+# End/tail: extend the too-short EOS-drain wait so the tail plays out instead of being
+# flushed (sem_clockfix), and hold the amp mix until the drain actually finishes
+# (audio_stopdelay), coupled by a cross-process "tail drained" event so the amp releases
+# exactly when the audio ends, not after a guessed delay.
 # Default: false
 aa_audio_low_latency = false


### PR DESCRIPTION
Introduce the AA guidance audio fix shims that stop the prompt being clipped at both ends

- aap_service/audio/goactive.cpp: self-activate the guidance pipeline after a 3-frame pre-roll so dense/back-to-back prompts don't clip their head.
- aap_service/audio/sem_clockfix.cpp: extend the too-short EOS-drain sem_timedwait so the tail plays out instead of being flushed, then post a cross-process drain-done token.
- blmjciaapa/audio/audio_stopdelay.cpp: hold the amp mix until that token arrives, so the amp un-mixes exactly when the tail ends (event-driven; no dead-air, no cut) with a fail-safe cap.
- blmjciaapa/audio/audio_keepalive.cpp: hold one dmix client open so hw:0,0 stays warm and the first prompt over a tuner isn't lost to a cold open.
- common/audio/drain_event.h: SysV-semaphore drain-done event coupling sem_clockfix (producer) to audio_stopdelay (consumer).