### PR TITLE
Add 'Accessory' for the Carlinkit dongle to the device list in bt16pa…

### DIFF
--- a/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
+++ b/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
@@ -49,7 +49,8 @@ constexpr char const *kDongleDevNames[] = {
     "carplay",
     "carlink",
     "motorolama1",
-    "AutoKit"
+    "AutoKit",
+    "Accessory"
 };
 
 // AapConnectionManager connect-mode values (instance + 0xdc). Offset and


### PR DESCRIPTION
Carlinkit dongle is named as 'Accessory'. Adds 'Accessory' as device name.
<img width="493" height="356" alt="imagen" src="https://github.com/user-attachments/assets/a69d9818-e243-4825-bffa-a9c6900a373d" />
