### PR TITLE
Add "CAR2" to the list of bluetooth devices.

### DIFF
--- a/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
+++ b/mazda/patches/blmjciaapa/bt16pair/bt16pair.cpp
@@ -50,7 +50,8 @@ constexpr char const *kDongleDevNames[] = {
     "carlink",
     "motorolama1",
     "AutoKit",
-    "Accessory"
+    "Accessory",
+    "CAR2"
 };
 
 // AapConnectionManager connect-mode values (instance + 0xdc). Offset and


### PR DESCRIPTION
Added "CAR2" to the list of bluetooth devices.
It is for the Ottocast Mini Aura.